### PR TITLE
fix: replace rm with del

### DIFF
--- a/mediapipe/examples/android/solutions/create_win_symlinks.bat
+++ b/mediapipe/examples/android/solutions/create_win_symlinks.bat
@@ -4,19 +4,19 @@
 @rem for hands example app.
 cd /d %~dp0
 cd hands\src\main
-rm res
+del res
 mklink /d res ..\..\..\res
 
 @rem for facemesh example app.
 cd /d %~dp0
 cd facemesh\src\main
-rm res
+del res
 mklink /d res ..\..\..\res
 
 @rem for face detection example app.
 cd /d %~dp0
 cd facedetection\src\main
-rm res
+del res
 mklink /d res ..\..\..\res
 
 dir


### PR DESCRIPTION
Since the rm command cannot be used in a Windows batch file, replace it with del.