### PR TITLE
fix: OpenCL init should fail on non-android platforms

### DIFF
--- a/mediapipe/util/tflite/tflite_gpu_runner.cc
+++ b/mediapipe/util/tflite/tflite_gpu_runner.cc
@@ -215,7 +215,7 @@ absl::Status TFLiteGPURunner::InitializeOpenCL(
       cl_options, std::move(*graph_cl_), builder));
   return absl::OkStatus();
 #endif
-  return mediapipe::UnimplementedError("OpenCL is only supported on Android currently.");
+  return mediapipe::UnimplementedError("OpenCL is currently only supported on Android.");
 }
 
 }  // namespace gpu


### PR DESCRIPTION
Fixes `use_advanced_gpu_api` graphs on Linux and other non-android platforms.

See: #2170 #2251 #2463