### PR TITLE
Use absl::Status and co explicitly

### DIFF
--- a/mediapipe/calculators/core/matrix_to_vector_calculator.cc
+++ b/mediapipe/calculators/core/matrix_to_vector_calculator.cc
@@ -58,7 +58,7 @@ MEDIAPIPE_REGISTER_NODE(MatrixToVectorCalculator);
 
 absl::Status MatrixToVectorCalculator::Open(CalculatorContext* cc) {
   cc->SetOffset(0);
-  return mediapipe::OkStatus();
+  return absl::OkStatus();
 }
 
 absl::Status MatrixToVectorCalculator::Process(CalculatorContext* cc) {

--- a/mediapipe/calculators/tensor/inference_calculator.cc
+++ b/mediapipe/calculators/tensor/inference_calculator.cc
@@ -63,7 +63,7 @@ absl::StatusOr<Packet<TfLiteModelPtr>> InferenceCalculator::GetModelAsPacket(
     return TfLiteModelLoader::LoadFromPath(options.model_path());
   }
   if (!kSideInModel(cc).IsEmpty()) return kSideInModel(cc);
-  return absl::Status(mediapipe::StatusCode::kNotFound,
+  return absl::Status(absl::StatusCode::kNotFound,
                       "Must specify TFLite model as path or loaded model.");
 }
 

--- a/mediapipe/examples/desktop/autoflip/quality/scene_camera_motion_analyzer.cc
+++ b/mediapipe/examples/desktop/autoflip/quality/scene_camera_motion_analyzer.cc
@@ -367,7 +367,8 @@ absl::Status SceneCameraMotionAnalyzer::PopulateFocusPointFrames(
         scene_summary, focus_point_frame_type, scene_frame_timestamps,
         focus_point_frames);
   } else {
-    return absl::Status(StatusCode::kInvalidArgument, "Unknown motion type.");
+    return absl::Status(absl::StatusCode::kInvalidArgument,
+                        "Unknown motion type.");
   }
 }
 

--- a/mediapipe/examples/desktop/autoflip/quality/visual_scorer_test.cc
+++ b/mediapipe/examples/desktop/autoflip/quality/visual_scorer_test.cc
@@ -50,7 +50,7 @@ TEST(VisualScorerTest, ScoresSharpness) {
   image_mat.setTo(cv::Scalar(0, 0, 0));
   float score_rect = 0;
   auto status = scorer.CalculateScore(image_mat, region, &score_rect);
-  EXPECT_EQ(status.code(), StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
 }
 
 TEST(VisualScorerTest, ScoresColorfulness) {

--- a/mediapipe/framework/api2/packet.h
+++ b/mediapipe/framework/api2/packet.h
@@ -257,19 +257,19 @@ struct First {
 
 template <class T>
 struct AddStatus {
-  using type = StatusOr<T>;
+  using type = absl::StatusOr<T>;
 };
 template <class T>
-struct AddStatus<StatusOr<T>> {
-  using type = StatusOr<T>;
+struct AddStatus<absl::StatusOr<T>> {
+  using type = absl::StatusOr<T>;
 };
 template <>
-struct AddStatus<Status> {
-  using type = Status;
+struct AddStatus<absl::Status> {
+  using type = absl::Status;
 };
 template <>
 struct AddStatus<void> {
-  using type = Status;
+  using type = absl::Status;
 };
 
 template <class R, class F, class... A>
@@ -280,7 +280,7 @@ struct CallAndAddStatusImpl {
 };
 template <class F, class... A>
 struct CallAndAddStatusImpl<void, F, A...> {
-  Status operator()(const F& f, A&&... a) {
+  absl::Status operator()(const F& f, A&&... a) {
     f(std::forward<A>(a)...);
     return {};
   }

--- a/mediapipe/framework/deps/status_builder.cc
+++ b/mediapipe/framework/deps/status_builder.cc
@@ -69,14 +69,14 @@ StatusBuilder&& StatusBuilder::SetNoLogging() && {
   return std::move(SetNoLogging());
 }
 
-StatusBuilder::operator Status() const& {
+StatusBuilder::operator absl::Status() const& {
   if (!stream_ || stream_->str().empty() || no_logging_) {
     return status_;
   }
   return StatusBuilder(*this).JoinMessageToStatus();
 }
 
-StatusBuilder::operator Status() && {
+StatusBuilder::operator absl::Status() && {
   if (!stream_ || stream_->str().empty() || no_logging_) {
     return status_;
   }
@@ -97,7 +97,7 @@ absl::Status StatusBuilder::JoinMessageToStatus() {
                   ? absl::StrCat(stream_->str(), status_.message())
                   : absl::StrCat(status_.message(), stream_->str());
   }
-  return Status(status_.code(), message);
+  return absl::Status(status_.code(), message);
 }
 
 }  // namespace mediapipe

--- a/mediapipe/framework/deps/status_builder.h
+++ b/mediapipe/framework/deps/status_builder.h
@@ -92,8 +92,8 @@ class ABSL_MUST_USE_RESULT StatusBuilder {
     return std::move(*this << msg);
   }
 
-  operator Status() const&;
-  operator Status() &&;
+  operator absl::Status() const&;
+  operator absl::Status() &&;
 
   absl::Status JoinMessageToStatus();
 

--- a/mediapipe/framework/deps/status_test.cc
+++ b/mediapipe/framework/deps/status_test.cc
@@ -30,7 +30,7 @@ TEST(Status, OK) {
 }
 
 TEST(DeathStatus, CheckOK) {
-  Status status(absl::StatusCode::kInvalidArgument, "Invalid");
+  absl::Status status(absl::StatusCode::kInvalidArgument, "Invalid");
   ASSERT_DEATH(MEDIAPIPE_CHECK_OK(status), "Invalid");
 }
 

--- a/mediapipe/framework/output_stream_shard.cc
+++ b/mediapipe/framework/output_stream_shard.cc
@@ -94,7 +94,7 @@ const Packet& OutputStreamShard::Header() const {
 // binary.  This function can be defined in the .cc file because only two
 // versions are ever instantiated, and all call sites are within this .cc file.
 template <typename T>
-Status OutputStreamShard::AddPacketInternal(T&& packet) {
+absl::Status OutputStreamShard::AddPacketInternal(T&& packet) {
   if (IsClosed()) {
     return mediapipe::FailedPreconditionErrorBuilder(MEDIAPIPE_LOC)
            << "Packet sent to closed stream \"" << Name() << "\".";
@@ -113,7 +113,7 @@ Status OutputStreamShard::AddPacketInternal(T&& packet) {
            << timestamp.DebugString();
   }
 
-  Status result = output_stream_spec_->packet_type->Validate(packet);
+  absl::Status result = output_stream_spec_->packet_type->Validate(packet);
   if (!result.ok()) {
     return StatusBuilder(result, MEDIAPIPE_LOC).SetPrepend() << absl::StrCat(
                "Packet type mismatch on calculator outputting to stream \"",
@@ -132,14 +132,14 @@ Status OutputStreamShard::AddPacketInternal(T&& packet) {
 }
 
 void OutputStreamShard::AddPacket(const Packet& packet) {
-  Status status = AddPacketInternal(packet);
+  absl::Status status = AddPacketInternal(packet);
   if (!status.ok()) {
     output_stream_spec_->TriggerErrorCallback(status);
   }
 }
 
 void OutputStreamShard::AddPacket(Packet&& packet) {
-  Status status = AddPacketInternal(std::move(packet));
+  absl::Status status = AddPacketInternal(std::move(packet));
   if (!status.ok()) {
     output_stream_spec_->TriggerErrorCallback(status);
   }

--- a/mediapipe/framework/packet.cc
+++ b/mediapipe/framework/packet.cc
@@ -144,7 +144,7 @@ const proto_ns::MessageLite& Packet::GetProtoMessageLite() const {
   return *proto;
 }
 
-StatusOr<std::vector<const proto_ns::MessageLite*>>
+absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
 Packet::GetVectorOfProtoMessageLitePtrs() const {
   if (holder_ == nullptr) {
     return absl::InternalError("Packet is empty.");

--- a/mediapipe/framework/packet.h
+++ b/mediapipe/framework/packet.h
@@ -174,7 +174,7 @@ class Packet {
   // object type is a vector of MessageLite data, returns an error otherwise.
   // Note: This function is meant to be used internally within the MediaPipe
   // framework only.
-  StatusOr<std::vector<const proto_ns::MessageLite*>>
+  absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
   GetVectorOfProtoMessageLitePtrs() const;
 
   // Returns an error if the packet does not contain data of type T.
@@ -394,7 +394,7 @@ class HolderBase {
   // Returns a vector<MessageLite*> for the data in the holder, if the
   // underlying object is a vector of protocol buffer objects, otherwise,
   // returns an error.
-  virtual StatusOr<std::vector<const proto_ns::MessageLite*>>
+  virtual absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
   GetVectorOfProtoMessageLite() const = 0;
 
   virtual bool HasForeignOwner() const { return false; }
@@ -424,7 +424,7 @@ struct is_proto_vector<std::vector<ItemT, Allocator>>
 // Helper function to create and return a vector of pointers to proto message
 // elements of the vector passed into the function.
 template <typename T>
-StatusOr<std::vector<const proto_ns::MessageLite*>>
+absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
 ConvertToVectorOfProtoMessageLitePtrs(const T* data,
                                       /*is_proto_vector=*/std::false_type) {
   return absl::InvalidArgumentError(absl::StrCat(
@@ -433,7 +433,7 @@ ConvertToVectorOfProtoMessageLitePtrs(const T* data,
 }
 
 template <typename T>
-StatusOr<std::vector<const proto_ns::MessageLite*>>
+absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
 ConvertToVectorOfProtoMessageLitePtrs(const T* data,
                                       /*is_proto_vector=*/std::true_type) {
   std::vector<const proto_ns::MessageLite*> result;
@@ -562,7 +562,7 @@ class Holder : public HolderBase {
   // Returns a vector<MessageLite*> for the data in the holder, if the
   // underlying object is a vector of protocol buffer objects, otherwise,
   // returns an error.
-  StatusOr<std::vector<const proto_ns::MessageLite*>>
+  absl::StatusOr<std::vector<const proto_ns::MessageLite*>>
   GetVectorOfProtoMessageLite() const override {
     return ConvertToVectorOfProtoMessageLitePtrs(ptr_, is_proto_vector<T>());
   }

--- a/mediapipe/framework/packet_test.cc
+++ b/mediapipe/framework/packet_test.cc
@@ -496,7 +496,7 @@ TEST(PacketTest, PacketFromSerializedProto) {
   original.add_value("foo");
   std::string serialized = original.SerializeAsString();
 
-  StatusOr<Packet> maybe_packet = packet_internal::PacketFromDynamicProto(
+  absl::StatusOr<Packet> maybe_packet = packet_internal::PacketFromDynamicProto(
       "mediapipe.SimpleProto", serialized);
   MP_ASSERT_OK(maybe_packet);
   Packet packet = maybe_packet.value();

--- a/mediapipe/framework/profiler/graph_profiler.cc
+++ b/mediapipe/framework/profiler/graph_profiler.cc
@@ -670,7 +670,7 @@ absl::Status GraphProfiler::CaptureProfile(
   previous_log_end_time_ = end_time;
 
   // Record the latest CalculatorProfiles.
-  Status status;
+  absl::Status status;
   std::vector<CalculatorProfile> profiles;
   status.Update(GetCalculatorProfiles(&profiles));
   for (CalculatorProfile& p : profiles) {

--- a/mediapipe/framework/profiler/profiler_resource_util.cc
+++ b/mediapipe/framework/profiler/profiler_resource_util.cc
@@ -16,7 +16,7 @@
 
 namespace mediapipe {
 
-StatusOr<std::string> GetDefaultTraceLogDirectory() {
+absl::StatusOr<std::string> GetDefaultTraceLogDirectory() {
   return std::string("/tmp");
 }
 

--- a/mediapipe/framework/profiler/profiler_resource_util.h
+++ b/mediapipe/framework/profiler/profiler_resource_util.h
@@ -25,11 +25,11 @@ namespace mediapipe {
 // Returns the path to the directory where trace logs will be stored by default.
 // If the function is unable to find an appropriate directory, it returns an
 // error.
-StatusOr<std::string> GetDefaultTraceLogDirectory();
+absl::StatusOr<std::string> GetDefaultTraceLogDirectory();
 
 // Given a log file path, this function provides an absolute path with which
 // it can be accessed as a file.  Enclosing directories are created as needed.
-StatusOr<std::string> PathToLogFile(const std::string& path);
+absl::StatusOr<std::string> PathToLogFile(const std::string& path);
 
 }  // namespace mediapipe
 

--- a/mediapipe/framework/profiler/profiler_resource_util_android.cc
+++ b/mediapipe/framework/profiler/profiler_resource_util_android.cc
@@ -20,11 +20,11 @@
 
 namespace mediapipe {
 
-StatusOr<std::string> GetDefaultTraceLogDirectory() {
+absl::StatusOr<std::string> GetDefaultTraceLogDirectory() {
   // The path to external storage directory on a device doesn't change when an
   // application is running, hence can be stored as global state.
-  static const StatusOr<std::string>* kExternalStorageDirectory = [] {
-    StatusOr<std::string>* result = new StatusOr<std::string>();
+  static const absl::StatusOr<std::string>* kExternalStorageDirectory = [] {
+    absl::StatusOr<std::string>* result = new absl::StatusOr<std::string>();
     bool has_jvm = java::HasJavaVM();
     if (!has_jvm) {
       *result = absl::InternalError("JavaVM not available.");

--- a/mediapipe/framework/profiler/profiler_resource_util_android_hal.cc
+++ b/mediapipe/framework/profiler/profiler_resource_util_android_hal.cc
@@ -2,7 +2,7 @@
 
 namespace mediapipe {
 
-StatusOr<std::string> GetDefaultTraceLogDirectory() {
+absl::StatusOr<std::string> GetDefaultTraceLogDirectory() {
   return "/data/local/tmp";
 }
 

--- a/mediapipe/framework/profiler/profiler_resource_util_ios.cc
+++ b/mediapipe/framework/profiler/profiler_resource_util_ios.cc
@@ -20,7 +20,7 @@
 
 namespace mediapipe {
 
-StatusOr<std::string> GetDefaultTraceLogDirectory() {
+absl::StatusOr<std::string> GetDefaultTraceLogDirectory() {
   // Get the Documents directory. iOS apps can write files to this directory.
   NSURL* documents_directory_url = [[[NSFileManager defaultManager]
       URLsForDirectory:NSDocumentDirectory

--- a/mediapipe/framework/profiler/reporter_test.cc
+++ b/mediapipe/framework/profiler/reporter_test.cc
@@ -146,14 +146,14 @@ TEST(Reporter, PrintAllColumns) {
 TEST(Reporter, CanReportBadColumns) {
   auto reporter = loadReporter({"profile_opencv_0.binarypb"});
   auto result = reporter->set_columns({"il[leg]al"});
-  EXPECT_EQ(result.code(), StatusCode::kInvalidArgument);
+  EXPECT_EQ(result.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(result.message(), "Column 'il[leg]al' is invalid.\n");
 }
 
 TEST(Reporter, CanReportNonMatchingColumns) {
   auto reporter = loadReporter({"profile_opencv_0.binarypb"});
   auto result = reporter->set_columns({"time_*", "il[leg]al"});
-  EXPECT_EQ(result.code(), StatusCode::kInvalidArgument);
+  EXPECT_EQ(result.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(result.message(), "Column 'il[leg]al' is invalid.\n");
   // Should not affect active columns, which is currently still "*".
   auto report = reporter->Report();
@@ -164,7 +164,7 @@ TEST(Reporter, CanReportNonMatchingColumns) {
 TEST(Reporter, BadPatternsIgnored) {
   auto reporter = loadReporter({"profile_opencv_0.binarypb"});
   auto result = reporter->set_columns({"time_mean", "il[leg]al", "^bad"});
-  EXPECT_EQ(result.code(), StatusCode::kInvalidArgument);
+  EXPECT_EQ(result.code(), absl::StatusCode::kInvalidArgument);
   // Can report multiple errors at once, separated by newlines.
   EXPECT_EQ(result.message(),
             "Column 'il[leg]al' is invalid.\n"
@@ -177,7 +177,7 @@ TEST(Reporter, BadPatternsIgnored) {
 TEST(Reporter, NonMatchingColumnsIgnored) {
   auto reporter = loadReporter({"profile_opencv_0.binarypb"});
   auto result = reporter->set_columns({"koopa*"});
-  EXPECT_EQ(result.code(), StatusCode::kInvalidArgument);
+  EXPECT_EQ(result.code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(result.message(), "Column 'koopa*' did not match any columns.\n");
 }
 

--- a/mediapipe/framework/tool/options_field_util.cc
+++ b/mediapipe/framework/tool/options_field_util.cc
@@ -268,7 +268,7 @@ FieldData SerializeProtobufAny(const FieldData& data) {
 }
 
 // Returns the field index of an extension type in a repeated field.
-StatusOr<int> FindExtensionIndex(const FieldData& message_data,
+absl::StatusOr<int> FindExtensionIndex(const FieldData& message_data,
                                  FieldPathEntry* entry) {
   if (entry->field == nullptr || !IsProtobufAny(entry->field)) {
     return -1;
@@ -447,7 +447,7 @@ absl::Status GetNodeOptions(const FieldData& message_data,
   std::string parent_type = options_field_util::ParseTypeUrl(
       std::string(message_data.message_value().type_url()));
   FieldPath path;
-  Status status;
+  absl::Status status;
   path = GetExtensionPath(parent_type, extension_type, kOptionsName, false);
   status = GetField(path, message_data, result);
   if (status.ok()) {
@@ -467,7 +467,7 @@ absl::Status GetGraphOptions(const FieldData& message_data,
   std::string parent_type = options_field_util::ParseTypeUrl(
       std::string(message_data.message_value().type_url()));
   FieldPath path;
-  Status status;
+  absl::Status status;
   path = GetExtensionPath(parent_type, extension_type, kOptionsName, false);
   status = GetField(path, message_data, result);
   if (status.ok()) {

--- a/mediapipe/framework/tool/options_util.cc
+++ b/mediapipe/framework/tool/options_util.cc
@@ -59,7 +59,7 @@ std::string MessageType(FieldData message) {
 // Copy literal options from graph_options to node_options.
 absl::Status CopyLiteralOptions(CalculatorGraphConfig::Node parent_node,
                                 CalculatorGraphConfig* config) {
-  Status status;
+  absl::Status status;
   FieldData graph_data = options_field_util::AsFieldData(*config);
   FieldData parent_data = options_field_util::AsFieldData(parent_node);
 
@@ -105,7 +105,7 @@ absl::Status CopyLiteralOptions(CalculatorGraphConfig::Node parent_node,
 absl::Status DefineGraphOptions(const CalculatorGraphConfig::Node& parent_node,
                                 CalculatorGraphConfig* config) {
   MP_RETURN_IF_ERROR(CopyLiteralOptions(parent_node, config));
-  return mediapipe::OkStatus();
+  return absl::OkStatus();
 }
 
 }  // namespace tool

--- a/mediapipe/framework/tool/options_util_test.cc
+++ b/mediapipe/framework/tool/options_util_test.cc
@@ -37,15 +37,15 @@ using FieldType = ::mediapipe::proto_ns::FieldDescriptorProto::Type;
 class NightLightCalculator : public CalculatorBase {
  public:
   static absl::Status GetContract(CalculatorContract* cc) {
-    return mediapipe::OkStatus();
+    return absl::OkStatus();
   }
 
   absl::Status Open(CalculatorContext* cc) final {
-    return mediapipe::OkStatus();
+    return absl::OkStatus();
   }
 
   absl::Status Process(CalculatorContext* cc) final {
-    return mediapipe::OkStatus();
+    return absl::OkStatus();
   }
 
  private:

--- a/mediapipe/framework/tool/status_util.cc
+++ b/mediapipe/framework/tool/status_util.cc
@@ -58,8 +58,8 @@ absl::Status CombinedStatus(const std::string& general_comment,
       }
     }
   }
-  if (error_code == StatusCode::kOk) return OkStatus();
-  Status combined = absl::Status(
+  if (error_code == absl::StatusCode::kOk) return absl::OkStatus();
+  absl::Status combined = absl::Status(
       error_code,
       absl::StrCat(general_comment, "\n", absl::StrJoin(errors, "\n")));
   return combined;

--- a/mediapipe/gpu/gpu_shared_data_internal.cc
+++ b/mediapipe/gpu/gpu_shared_data_internal.cc
@@ -149,7 +149,7 @@ absl::Status GpuResources::PrepareGpuNode(CalculatorNode* node) {
   context->SetProfilingContext(
       node->GetCalculatorState().GetSharedProfilingContext());
 
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // TODO: expose and use an actual ID instead of using the

--- a/mediapipe/util/tensor_to_detection.cc
+++ b/mediapipe/util/tensor_to_detection.cc
@@ -56,12 +56,12 @@ Detection TensorToDetection(
   return detection;
 }
 
-Status TensorsToDetections(const ::tensorflow::Tensor& num_detections,
-                           const ::tensorflow::Tensor& boxes,
-                           const ::tensorflow::Tensor& scores,
-                           const ::tensorflow::Tensor& classes,
-                           const std::map<int, std::string>& label_map,
-                           std::vector<Detection>* detections) {
+absl::Status TensorsToDetections(const ::tensorflow::Tensor& num_detections,
+                                 const ::tensorflow::Tensor& boxes,
+                                 const ::tensorflow::Tensor& scores,
+                                 const ::tensorflow::Tensor& classes,
+                                 const std::map<int, std::string>& label_map,
+                                 std::vector<Detection>* detections) {
   const ::tensorflow::Tensor empty_keypoints = ::tensorflow::Tensor(
       ::tensorflow::DT_FLOAT, ::tensorflow::TensorShape({0, 0, 0}));
   const ::tensorflow::Tensor empty_masks = ::tensorflow::Tensor(
@@ -71,15 +71,15 @@ Status TensorsToDetections(const ::tensorflow::Tensor& num_detections,
                              /*mask_threshold=*/0.0f, label_map, detections);
 }
 
-Status TensorsToDetections(const ::tensorflow::Tensor& num_detections,
-                           const ::tensorflow::Tensor& boxes,
-                           const ::tensorflow::Tensor& scores,
-                           const ::tensorflow::Tensor& classes,
-                           const ::tensorflow::Tensor& keypoints,
-                           const ::tensorflow::Tensor& masks,
-                           float mask_threshold,
-                           const std::map<int, std::string>& label_map,
-                           std::vector<Detection>* detections) {
+absl::Status TensorsToDetections(const ::tensorflow::Tensor& num_detections,
+                                 const ::tensorflow::Tensor& boxes,
+                                 const ::tensorflow::Tensor& scores,
+                                 const ::tensorflow::Tensor& classes,
+                                 const ::tensorflow::Tensor& keypoints,
+                                 const ::tensorflow::Tensor& masks,
+                                 float mask_threshold,
+                                 const std::map<int, std::string>& label_map,
+                                 std::vector<Detection>* detections) {
   int num_boxes = -1;
   if (num_detections.dims() > 0 && num_detections.dim_size(0) != 0) {
     if (num_detections.dtype() != tf::DT_INT32) {


### PR DESCRIPTION
MediaPipe exposes `mediapipe::Status`, `mediapipe::StatusCode`, `mediapipe::StatusOr<>` and `mediapipe::OkStatus()` which are aliases to their Abseil counterparts. Those aliases have been marked as deprecated, as shown here, for example: https://github.com/google/mediapipe/blob/c6c80c37452d0938b1577bd1ad44ad096ca918e0/mediapipe/framework/deps/status.h#L30

When building with warnings turned on, deprecation warnings end up spamming the build logs quite a lot, and play a part in being unable to treat warnings as errors in external code that includes some of MediaPipe's public headers.

This PR aims at removing all the uses I could find internally in the MediaPipe codebase.
Ideally I'd also like to remove the aliases themselves, but I realize this could break 3rd party code despite the deprecation flag because the warnings are silenced by default in `.bazelrc`, so I left them in.
I also left https://github.com/google/mediapipe/blob/master/mediapipe/framework/deps/status_test.cc mostly untouched, although 95% of it only tests Abseil's implementation. The test cases I did not touch could probably be safely deleted.