### PR TITLE
Update Dockerfile to install libopencv-contrib-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libopencv-video-dev \
         libopencv-calib3d-dev \
         libopencv-features2d-dev \
+        libopencv-contrib-dev \
         software-properties-common && \
     add-apt-repository -y ppa:openjdk-r/ppa && \
     apt-get update && apt-get install -y openjdk-8-jdk && \


### PR DESCRIPTION
Update ```Dockerfile``` to install ```libopencv-contrib-dev``` that contains a file ```opencv2/optflow.hpp``` required by ```framework/port/opencv_video_inc.h``` Closes #3835