### PR TITLE
Fix supported platforms table in javascript.md

### DIFF
--- a/docs/getting_started/javascript.md
+++ b/docs/getting_started/javascript.md
@@ -31,13 +31,11 @@ snippets.
 
 ### Supported plaforms:
 
-| Browser | Platform                | Notes                                  |
-| ------- | ----------------------- | -------------------------------------- |
-| Chrome  | Android / Windows / Mac | Pixel 4 and older unsupported. Fuschia |
-|         |                         | unsupported.                           |
-| Chrome  | iOS                     | Camera unavailable in Chrome on iOS.   |
-| Safari  | iPad/iPhone/Mac         | iOS and Safari on iPad / iPhone /      |
-|         |                         | MacBook                                |
+| Browser | Platform                | Notes                                               |
+|---------|-------------------------|-----------------------------------------------------|
+| Chrome  | Android / Windows / Mac | Pixel 4 and older unsupported. Fuschia unsupported. |
+| Chrome  | iOS                     | Camera unavailable in Chrome on iOS.                |
+| Safari  | iPad/iPhone/Mac         | iOS and Safari on iPad / iPhone / MacBook           |
 
 The quickest way to get acclimated is to look at the examples above. Each demo
 has a link to a [CodePen][codepen] so that you can edit the code and try it


### PR DESCRIPTION
Fixes an incorrectly formatted table in the documentation for the Javascript getting started guide
Old:
![image](https://user-images.githubusercontent.com/56329333/211997713-0b518c52-4d15-4a2b-b7b0-b98b1d1a4548.png)

New:
![image](https://user-images.githubusercontent.com/56329333/211997992-84cd2c0d-e151-48b6-93ff-43e3037e676c.png)

