### PR TITLE
Added more methods to iOS MPPAudioTaskRunner

### DIFF
--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.h
@@ -28,7 +28,7 @@ NS_SWIFT_NAME(AudioDataFormat)
 @property(nonatomic, readonly) NSUInteger channelCount;
 
 /** Sample rate */
-@property(nonatomic, readonly) NSUInteger sampleRate;
+@property(nonatomic, readonly) double sampleRate;
 
 /**
  * Initializes a new `AudioDataFormat` with the given channel count and sample rate.
@@ -38,7 +38,7 @@ NS_SWIFT_NAME(AudioDataFormat)
  *
  * @return A new instance of `AudioDataFormat` with the given channel count and sample rate.
  */
-- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate;
+- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(double)sampleRate;
 
 /**
  * Initializes a new `AudioDataFormat` with the default channel count of 1 and the given sample
@@ -48,7 +48,7 @@ NS_SWIFT_NAME(AudioDataFormat)
  * @return A new instance of `AudioDataFormat` with the default channel count of 1 and the given
  * sample rate.
  */
-- (instancetype)initWithSampleRate:(NSUInteger)sampleRate;
+- (instancetype)initWithSampleRate:(double)sampleRate;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.m
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioDataFormat.m
@@ -18,7 +18,7 @@ static const NSInteger kDefaultChannelCount = 1;
 
 @implementation MPPAudioDataFormat
 
-- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(NSUInteger)sampleRate {
+- (instancetype)initWithChannelCount:(NSUInteger)channelCount sampleRate:(double)sampleRate {
   self = [super init];
   if (self) {
     _channelCount = channelCount;
@@ -27,7 +27,7 @@ static const NSInteger kDefaultChannelCount = 1;
   return self;
 }
 
-- (instancetype)initWithSampleRate:(NSUInteger)sampleRate {
+- (instancetype)initWithSampleRate:(double)sampleRate {
   return [self initWithChannelCount:kDefaultChannelCount sampleRate:sampleRate];
 }
 

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioTaskRunner.h
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioTaskRunner.h
@@ -75,6 +75,27 @@ NS_ASSUME_NONNULL_BEGIN
 - (std::optional<mediapipe::tasks::core::PacketMap>)processAudioClip:(MPPAudioData *)audioClip
                                                                error:(NSError **)error;
 
+/**
+ * An asynchronous method to send audio stream data to the C++ task runner. The call returns
+ * immediately indicating if the audio clip was sent successfully to the C++ task runner. The
+ * results will be available in the user-defined `packetsCallback` that was provided during
+ * initialization of the `MPPAudioTaskRunner`.
+ *
+ * @param audioClip An audio clip input of type `MPPAudioData` to the task.
+ * @param timestampInMilliseconds The audio clip's timestamp (in milliseconds). The input timestamps
+ * must be monotonically increasing.
+ * @param error Pointer to the memory location where errors if any should be saved. If @c NULL, no
+ * error will be saved.
+ *
+ * @return A `BOOL` indicating if the audio stream data was sent to the C++ task runner
+ * successfully. Please note that any errors during processing of the audio stream packet map will
+ * only be available in the user-defined `packetsCallback` that was provided during initialization
+ * of the `MPPAudioTaskRunner`.
+ */
+- (BOOL)processStreamAudioClip:(MPPAudioData *)audioClip
+       timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                         error:(NSError **)error;
+
 - (instancetype)initWithTaskInfo:(MPPTaskInfo *)taskInfo
                  packetsCallback:(mediapipe::tasks::core::PacketsCallback)packetsCallback
                            error:(NSError **)error NS_UNAVAILABLE;

--- a/mediapipe/tasks/ios/audio/core/sources/MPPAudioTaskRunner.mm
+++ b/mediapipe/tasks/ios/audio/core/sources/MPPAudioTaskRunner.mm
@@ -25,16 +25,19 @@
 
 namespace {
 using ::mediapipe::Packet;
+using ::mediapipe::Timestamp;
 using ::mediapipe::tasks::core::PacketMap;
 using ::mediapipe::tasks::core::PacketsCallback;
 }  // namespace
 
 static NSString *const kTaskPrefix = @"com.mediapipe.tasks.audio";
+static const double kInitialDefaultSampleRate = -1.0f;
 
 @interface MPPAudioTaskRunner () {
   MPPAudioRunningMode _runningMode;
   NSString *_audioInputStreamName;
   NSString *_sampleRateInputStreamName;
+  double _sampleRate;
 }
 @end
 
@@ -103,6 +106,7 @@ static NSString *const kTaskPrefix = @"com.mediapipe.tasks.audio";
   }
 
   _runningMode = runningMode;
+  _sampleRate = kInitialDefaultSampleRate;
 
   self = [super initWithTaskInfo:taskInfo packetsCallback:packetsCallback error:error];
   return self;
@@ -127,6 +131,70 @@ static NSString *const kTaskPrefix = @"com.mediapipe.tasks.audio";
                                     : std::nullopt;
 }
 
+- (BOOL)processStreamAudioClip:(MPPAudioData *)audioClip
+       timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                         error:(NSError **)error {
+  if (_runningMode != MPPAudioRunningModeAudioStream) {
+    [MPPCommonUtils
+        createCustomError:error
+                 withCode:MPPTasksErrorCodeInvalidArgumentError
+              description:[NSString stringWithFormat:@"The audio task is not initialized with "
+                                                     @"audio stream mode. Current Running Mode: %@",
+                                                     MPPAudioRunningModeDisplayName(_runningMode)]];
+    return NO;
+  }
+
+  if (![self checkOrSetSampleRate:audioClip.format.sampleRate error:error]) {
+    return NO;
+  }
+
+  Packet matrixPacket = [MPPAudioPacketCreator createPacketWithAudioData:audioClip
+                                                 timestampInMilliseconds:timestampInMilliseconds
+                                                                   error:error];
+  if (matrixPacket.IsEmpty()) {
+    return NO;
+  }
+
+  PacketMap inputPacketMap = {{_audioInputStreamName.cppString, matrixPacket}};
+  return [self sendPacketMap:inputPacketMap error:error];
+}
+
+- (BOOL)checkOrSetSampleRate:(double)sampleRate error:(NSError **)error {
+  if (_runningMode != MPPAudioRunningModeAudioStream) {
+    [MPPCommonUtils
+        createCustomError:error
+                 withCode:MPPTasksErrorCodeInvalidArgumentError
+              description:[NSString stringWithFormat:@"The audio task is not initialized with "
+                                                     @"audio stream mode. Current Running Mode: %@",
+                                                     MPPAudioRunningModeDisplayName(_runningMode)]];
+    return NO;
+  }
+
+  if (_sampleRate <= 0) {
+    PacketMap inputPacketMap = {
+        {_sampleRateInputStreamName.cppString,
+         [MPPPacketCreator createWithDouble:sampleRate].At(Timestamp::PreStream())}};
+    BOOL sendStatus = [self sendPacketMap:inputPacketMap error:error];
+    if (sendStatus) {
+      _sampleRate = sampleRate;
+    }
+    return sendStatus;
+  }
+
+  if (sampleRate != _sampleRate) {
+    [MPPCommonUtils
+        createCustomError:error
+                 withCode:MPPTasksErrorCodeInvalidArgumentError
+              description:[NSString
+                              stringWithFormat:@"The input audio sample rate: %f is inconsistent "
+                                               @"with the previously provided: %f",
+                                               sampleRate, _sampleRate]];
+    return NO;
+  }
+
+  return YES;
+}
+
 - (std::optional<PacketMap>)inputPacketMapWithMPPAudioData:(MPPAudioData *)audioData
                                                      error:(NSError **)error {
   PacketMap inputPacketMap;
@@ -139,7 +207,7 @@ static NSString *const kTaskPrefix = @"com.mediapipe.tasks.audio";
   inputPacketMap[_audioInputStreamName.cppString] = matrixPacket;
 
   inputPacketMap[_sampleRateInputStreamName.cppString] =
-      [MPPPacketCreator createWithDouble:(double)audioData.format.sampleRate];
+      [MPPPacketCreator createWithDouble:audioData.format.sampleRate];
 
   return inputPacketMap;
 }

--- a/mediapipe/tasks/ios/test/audio/core/MPPAudioDataTests.mm
+++ b/mediapipe/tasks/ios/test/audio/core/MPPAudioDataTests.mm
@@ -27,7 +27,7 @@ static MPPFileInfo *const kSpeech16KHzMonoFileInfo =
 
 static AVAudioFormat *const kAudioEngineFormat =
     [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
-                                     sampleRate:48000
+                                     sampleRate:48000.0f
                                        channels:1
                                     interleaved:YES];
 
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testInitWithFormatAndSampleCountSucceeds {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 1200;
 
   [MPPAudioDataTests asssertCreateAudioDataWithChannelCount:monoChannelCount
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadWithFloatBufferSucceeds {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 7;
 
   MPPAudioData *audioData =
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadWithFloatBufferAndOffsetSucceeds {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 7;
 
   MPPAudioData *audioData =
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadWithLengthOutOfBoundsFails {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 7;
 
   MPPAudioData *audioData =
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadWithOffsetOutOfBoundsFails {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 7;
 
   MPPAudioData *audioData =
@@ -201,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadFromShorterAudioRecordSucceeds {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 1000;
 
   const NSInteger bufferLength = 400;
@@ -229,7 +229,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testLoadFromLongerAudioRecordSucceeds {
   const NSInteger monoChannelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger sampleCount = 400;
 
   const NSInteger bufferLength = 1000;

--- a/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
+++ b/mediapipe/tasks/ios/test/audio/core/MPPAudioRecordTests.mm
@@ -30,7 +30,7 @@ static MPPFileInfo *const kSpeech48KHzMonoFileInfo =
 
 static AVAudioFormat *const kAudioEngineFormat =
     [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
-                                     sampleRate:48000
+                                     sampleRate:48000.0f
                                        channels:1
                                     interleaved:YES];
 
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testInitAudioRecordFailsWithInvalidChannelCount {
   const NSInteger channelCount = 3;
-  const NSInteger sampleRate = 8000;
+  const double sampleRate = 8000.0f;
   MPPAudioDataFormat *audioDataFormat =
       [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
 
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testInitAudioRecordFailsWithInvalidBufferLength {
   const NSInteger channelCount = 2;
-  const NSInteger sampleRate = 8000;
+  const double sampleRate = 8000.0f;
   MPPAudioDataFormat *audioDataFormat =
       [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
 
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testConvertAndLoadAudioRecordWithMonoFormatSucceeds {
   const NSInteger channelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger bufferLength = 100;
 
   [MPPAudioRecordTests
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testConvertAndLoadAudioRecordWithStereoFormatSucceeds {
   const NSInteger channelCount = 2;
-  const NSInteger sampleRate = 8000;
+  const double sampleRate = 8000.0f;
   const NSInteger bufferLength = 200;
   [MPPAudioRecordTests
       assertCreateAndLoadAudioRecordSucceedsWithAudioFileInfo:kSpeech16KHzMonoFileInfo
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testReadAudioRecordAtOffsetFailsWithIndexOutOfBounds {
   const NSInteger channelCount = 1;
-  const NSInteger sampleRate = 16000;
+  const double sampleRate = 16000.0f;
   const NSInteger bufferLength = 100;
 
   MPPAudioRecord *audioRecord = [MPPAudioRecordTests


### PR DESCRIPTION
1. Added audio stream methods to audio task runner.
2. Changed type of sample rate to double for consistency with the native AVAudioFormat.