### PR TITLE
Fix calculators that include android file helpers with MEDIAPIPE_MOBILE

### DIFF
--- a/mediapipe/calculators/tensor/tensors_to_classification_calculator.cc
+++ b/mediapipe/calculators/tensor/tensors_to_classification_calculator.cc
@@ -26,7 +26,7 @@
 #include "mediapipe/framework/port/ret_check.h"
 #include "mediapipe/util/label_map.pb.h"
 #include "mediapipe/util/resource_util.h"
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else

--- a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc
+++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc
@@ -36,7 +36,7 @@
 #include "tensorflow/core/framework/node_def.pb.h"
 #include "tensorflow/core/public/session_options.h"
 
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/helpers.h"
 #else
 #include "mediapipe/framework/port/file_helpers.h"

--- a/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.cc
+++ b/mediapipe/calculators/tflite/tflite_tensors_to_classification_calculator.cc
@@ -26,7 +26,7 @@
 #include "mediapipe/framework/port/ret_check.h"
 #include "mediapipe/util/resource_util.h"
 #include "tensorflow/lite/interpreter.h"
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else

--- a/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc
+++ b/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc
@@ -24,7 +24,7 @@
 #include "mediapipe/util/label_map.pb.h"
 #include "mediapipe/util/resource_util.h"
 
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else

--- a/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.cc
+++ b/mediapipe/calculators/util/timed_box_list_id_to_label_calculator.cc
@@ -20,7 +20,7 @@
 #include "mediapipe/util/resource_util.h"
 #include "mediapipe/util/tracking/box_tracker.pb.h"
 
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else

--- a/mediapipe/calculators/util/top_k_scores_calculator.cc
+++ b/mediapipe/calculators/util/top_k_scores_calculator.cc
@@ -30,7 +30,7 @@
 #include "mediapipe/framework/port/statusor.h"
 #include "mediapipe/util/resource_util.h"
 
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else

--- a/mediapipe/calculators/video/box_detector_calculator.cc
+++ b/mediapipe/calculators/video/box_detector_calculator.cc
@@ -39,7 +39,7 @@
 #include "mediapipe/util/tracking/tracking.h"
 #include "mediapipe/util/tracking/tracking_visualization_utilities.h"
 
-#if defined(MEDIAPIPE_MOBILE)
+#if defined(MEDIAPIPE_ANDROID)
 #include "mediapipe/util/android/file/base/file.h"
 #include "mediapipe/util/android/file/base/helpers.h"
 #else


### PR DESCRIPTION
Several calculators include Android's file helpers by testing if `MEDIAPIPE_MOBILE` is defined, but it is also defined when [compiling with Emscripten](https://github.com/google-ai-edge/mediapipe/blob/60f537ba5daa6a044874c891ddd621c7b9aad80d/mediapipe/framework/port.h#L26), leading to compilation failures.

~~This PR simply substitute `MEDIAPIPE_MOBILE` to `MEDIAPIPE_ANDROID` which is specifically used by Android platform.~~

Edit: Later I found that iOS also use file helpers from `//mediapipe/util/android/file/base`, it might not be a good idea to make the changes outright. Close PR for now.