### PR TITLE
Fix error message for maxStorageBufferBindingSize

### DIFF
--- a/mediapipe/tasks/web/genai/llm_inference/llm_inference.ts
+++ b/mediapipe/tasks/web/genai/llm_inference/llm_inference.ts
@@ -301,7 +301,7 @@ export class LlmInference extends TaskRunner {
         `The WebGPU device is unable to execute LLM tasks, because the ` +
           `required maxStorageBufferBindingSize is at least ` +
           `${MAX_STORAGE_BUFFER_BINDING_SIZE_FOR_LLM} but your device only ` +
-          `supports maxStorageBufferBindingSize of ${systemBufferSizeLimit}`,
+          `supports maxStorageBufferBindingSize of ${systemStorageBufferBindingSizeLimit}`,
       );
     }
     let maxBufferSize;


### PR DESCRIPTION
The original error logs `systemBufferSizeLimit` when `adapter.limits.maxStorageBufferBindingSize` is below required minimum. It should be `systemStorageBufferBindingSizeLimit`.