### PR TITLE
Fix for isIOS() platform util on worker and non-worker contexts

### DIFF
--- a/mediapipe/web/graph_runner/platform_utils.ts
+++ b/mediapipe/web/graph_runner/platform_utils.ts
@@ -32,7 +32,9 @@ export function isIOS() {
     // tslint:disable-next-line:deprecation
   ].includes(navigator.platform)
       // iPad on iOS 13 detection
-      || (navigator.userAgent.includes('Mac') && 'ontouchend' in self.document);
+      || (navigator.userAgent.includes("Mac") && "document" in self
+      ? "ontouchend" in self.document
+      : false);
 }
 
 /**


### PR DESCRIPTION
Added a fix for `isIOS()` check to verify worker context or document context before attempting to access undefined objects, this caused a crash on Mac Chrome when I ran `tasks-vision` image segmenter