### PR TITLE
Added iOS Audio Embedder clips mode tests

### DIFF
--- a/mediapipe/tasks/ios/audio/audio_embedder/sources/MPPAudioEmbedder.h
+++ b/mediapipe/tasks/ios/audio/audio_embedder/sources/MPPAudioEmbedder.h
@@ -126,6 +126,22 @@ NS_SWIFT_NAME(AudioEmbedder)
                        error:(NSError **)error
     NS_SWIFT_NAME(classifyAsync(audioBlock:timestampInMilliseconds:));
 
+/**
+ * Closes and cleans up the MediaPipe audio embedder.
+ *
+ * For audio embedders initialized with `.audioStream` mode, ensure that this method is called
+ * after all audio blocks in an audio stream are sent for inference using
+ * `embedAsync(audioBlock:timestampInMilliseconds:)`. Otherwise, the audio embedder will not
+ * process the last audio block (of type `AudioData`) in the stream if its `bufferLength` is shorter
+ * than the model's input length. Once an audio embedder is closed, you cannot send any inference
+ * requests to it. You must create a new instance of `AudioEmbedder` to send any pending requests.
+ * Ensure that you are ready to dispose off the audio embedder before this method is invoked.
+ *
+ * @return Returns successfully if the task was closed. Otherwise, throws an error
+ * indicating the reason for failure.
+ */
+- (BOOL)closeWithError:(NSError **)error;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/mediapipe/tasks/ios/audio/audio_embedder/sources/MPPAudioEmbedder.mm
+++ b/mediapipe/tasks/ios/audio/audio_embedder/sources/MPPAudioEmbedder.mm
@@ -72,7 +72,7 @@ static const int kMicrosecondsPerMillisecond = 1000;
                                              kTimestampedEmbeddingsOutStreamName]
                 ]
                   taskOptions:options
-           enableFlowLimiting:options.runningMode == MPPAudioRunningModeAudioStream
+           enableFlowLimiting:NO
                         error:error];
 
     if (!taskInfo) {
@@ -152,6 +152,10 @@ static const int kMicrosecondsPerMillisecond = 1000;
                                                     sampleRate:sampleRate
                                                   bufferLength:bufferLength
                                                          error:error];
+}
+
+- (BOOL)closeWithError:(NSError **)error {
+  return [_audioTaskRunner closeWithError:error];
 }
 
 #pragma mark - Private

--- a/mediapipe/tasks/ios/test/audio/audio_classifier/MPPAudioClassifierTests.mm
+++ b/mediapipe/tasks/ios/test/audio/audio_classifier/MPPAudioClassifierTests.mm
@@ -352,8 +352,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   MPPAudioClassifier *audioClassifier =
       [MPPAudioClassifierTests audioClassifierWithOptions:options];
 
-  MPPAudioData *audioClip =
-     [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
+  MPPAudioData *audioClip = [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
   NSError *error;
   XCTAssertFalse([audioClassifier classifyAsyncAudioBlock:audioClip
                                   timestampInMilliseconds:0
@@ -380,8 +379,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   MPPAudioClassifier *audioClassifier =
       [MPPAudioClassifierTests audioClassifierWithOptions:options];
 
-  MPPAudioData *audioClip =
-      [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
+  MPPAudioData *audioClip = [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
 
   NSError *error;
   XCTAssertFalse([audioClassifier classifyAudioClip:audioClip error:&error]);
@@ -442,9 +440,9 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 - (void)testClassifyWithAudioStreamModeSucceeds {
   [self classifyUsingYamnetAsyncAudioFileWithInfo:kSpeech16KHzMonoFileInfo
-                                                 info:&_16kHZAudioStreamSucceedsTestDict];
+                                             info:&_16kHZAudioStreamSucceedsTestDict];
   [self classifyUsingYamnetAsyncAudioFileWithInfo:kSpeech48KHzMonoFileInfo
-                                                 info:&_48kHZAudioStreamSucceedsTestDict];
+                                             info:&_48kHZAudioStreamSucceedsTestDict];
 }
 
 - (void)audioClassifier:(MPPAudioClassifier *)audioClassifier
@@ -484,8 +482,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 // info is strong here since address of global variables will be passed to this function. By default
 // `NSDictionary **` will be `NSDictionary * __autoreleasing *.
 - (void)classifyUsingYamnetAsyncAudioFileWithInfo:(MPPFileInfo *)audioFileInfo
-                                                 info:(NSDictionary<NSString *, id> *__strong *)
-                                                          info {
+                                             info:(NSDictionary<NSString *, id> *__strong *)info {
   MPPAudioClassifier *audioClassifier =
       [self audioClassifierInStreamModeWithModelFileInfo:kYamnetModelFileInfo];
 
@@ -532,7 +529,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 - (MPPAudioClassifier *)audioClassifierInStreamModeWithModelFileInfo:(MPPFileInfo *)fileInfo {
   MPPAudioClassifierOptions *options =
-      [MPPAudioClassifierTests audioClassifierOptionsWithModelFileInfo:kYamnetModelFileInfo];
+      [MPPAudioClassifierTests audioClassifierOptionsWithModelFileInfo:fileInfo];
   options.runningMode = MPPAudioRunningModeAudioStream;
   options.audioClassifierStreamDelegate = self;
 

--- a/mediapipe/tasks/ios/test/audio/audio_classifier/MPPAudioClassifierTests.mm
+++ b/mediapipe/tasks/ios/test/audio/audio_classifier/MPPAudioClassifierTests.mm
@@ -353,7 +353,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
       [MPPAudioClassifierTests audioClassifierWithOptions:options];
 
   MPPAudioData *audioClip =
-      [MPPAudioClassifierTests audioDataFromAudioFileWithInfo:kSpeech16KHzMonoFileInfo];
+     [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
   NSError *error;
   XCTAssertFalse([audioClassifier classifyAsyncAudioBlock:audioClip
                                   timestampInMilliseconds:0
@@ -381,7 +381,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
       [MPPAudioClassifierTests audioClassifierWithOptions:options];
 
   MPPAudioData *audioClip =
-      [MPPAudioClassifierTests audioDataFromAudioFileWithInfo:kSpeech16KHzMonoFileInfo];
+      [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
 
   NSError *error;
   XCTAssertFalse([audioClassifier classifyAudioClip:audioClip error:&error]);
@@ -517,38 +517,6 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 #pragma mark Audio Data Initializers
 
-+ (MPPAudioData *)audioDataFromAudioFileWithInfo:(MPPFileInfo *)fileInfo {
-  // Load the samples from the audio file in `Float32` interleaved format to
-  // an `AVAudioPCMBuffer`.
-  AVAudioPCMBuffer *buffer =
-      [AVAudioPCMBuffer interleavedFloat32BufferFromAudioFileWithInfo:fileInfo];
-
-  // Create a float buffer from the `floatChannelData` of `AVAudioPCMBuffer`. This float buffer will
-  // be used to load the audio data.
-  MPPFloatBuffer *bufferData = [[MPPFloatBuffer alloc] initWithData:buffer.floatChannelData[0]
-                                                             length:buffer.frameLength];
-
-  MPPAudioData *audioData = [[MPPAudioData alloc] initWithChannelCount:buffer.format.channelCount
-                                                            sampleRate:buffer.format.sampleRate
-                                                           sampleCount:buffer.frameLength];
-
-  // Load all the samples in the audio file to the newly created audio data.
-  [audioData loadBuffer:bufferData offset:0 length:bufferData.length error:nil];
-  return audioData;
-}
-
-+ (MPPAudioData *)audioDataWithChannelCount:(NSUInteger)channelCount
-                                 sampleRate:(double)sampleRate
-                                sampleCount:(NSUInteger)sampleCount {
-  MPPAudioDataFormat *audioDataFormat =
-      [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
-
-  MPPAudioData *audioData = [[MPPAudioData alloc] initWithFormat:audioDataFormat
-                                                     sampleCount:sampleCount];
-
-  return audioData;
-}
-
 + (NSArray<MPPTimestampedAudioData *> *)streamedAudioDataListforYamnet {
   NSArray<MPPTimestampedAudioData *> *streamedAudioDataList =
       [AVAudioFile streamedAudioBlocksFromAudioFileWithInfo:kSpeech16KHzMonoFileInfo
@@ -656,7 +624,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 + (MPPAudioClassifierResult *)classifyAudioClipWithFileInfo:(MPPFileInfo *)fileInfo
                                        usingAudioClassifier:(MPPAudioClassifier *)audioClassifier {
-  MPPAudioData *audioData = [MPPAudioClassifierTests audioDataFromAudioFileWithInfo:fileInfo];
+  MPPAudioData *audioData = [[MPPAudioData alloc] initWithFileInfo:fileInfo];
   MPPAudioClassifierResult *result = [audioClassifier classifyAudioClip:audioData error:nil];
   XCTAssertNotNil(result);
 

--- a/mediapipe/tasks/ios/test/audio/audio_embedder/BUILD
+++ b/mediapipe/tasks/ios/test/audio/audio_embedder/BUILD
@@ -1,0 +1,63 @@
+load(
+    "@build_bazel_rules_apple//apple:ios.bzl",
+    "ios_unit_test",
+)
+load(
+    "@org_tensorflow//tensorflow/lite:special_rules.bzl",
+    "tflite_ios_lab_runner",
+)
+load(
+    "//mediapipe/framework/tool:ios.bzl",
+    "MPP_TASK_MINIMUM_OS_VERSION",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+# Default tags for filtering iOS targets. Targets are restricted to Apple platforms.
+TFL_DEFAULT_TAGS = [
+    "apple",
+]
+
+# Following sanitizer tests are not supported by iOS test targets.
+TFL_DISABLED_SANITIZER_TAGS = [
+    "noasan",
+    "nomsan",
+    "notsan",
+]
+
+objc_library(
+    name = "MPPAudioEmbedderObjcTestLibrary",
+    testonly = 1,
+    srcs = ["MPPAudioEmbedderTests.mm"],
+    copts = [
+        "-ObjC++",
+        "-std=c++17",
+        "-x objective-c++",
+    ],
+    data = [
+        "//mediapipe/tasks/testdata/audio:test_audio_clips",
+        "//mediapipe/tasks/testdata/audio:test_models",
+    ],
+    deps = [
+        "//mediapipe/tasks/ios/audio/audio_embedder:MPPAudioEmbedder",
+        "//mediapipe/tasks/ios/common:MPPCommon",
+        "//mediapipe/tasks/ios/common/utils:NSStringHelpers",
+        "//mediapipe/tasks/ios/test/audio/core/utils:AVAudioFileTestUtils",
+        "//mediapipe/tasks/ios/test/audio/core/utils:AVAudioPCMBufferTestUtils",
+        "//mediapipe/tasks/ios/test/audio/core/utils:MPPAudioDataTestUtils",
+        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
+        "//third_party/apple_frameworks:XCTest",
+    ],
+)
+
+ios_unit_test(
+    name = "MPPAudioEmbedderObjcTest",
+    minimum_os_version = MPP_TASK_MINIMUM_OS_VERSION,
+    runner = tflite_ios_lab_runner("IOS_LATEST"),
+    tags = TFL_DEFAULT_TAGS + TFL_DISABLED_SANITIZER_TAGS,
+    deps = [
+        ":MPPAudioEmbedderObjcTestLibrary",
+    ],
+)

--- a/mediapipe/tasks/ios/test/audio/audio_embedder/MPPAudioEmbedderTests.mm
+++ b/mediapipe/tasks/ios/test/audio/audio_embedder/MPPAudioEmbedderTests.mm
@@ -1,0 +1,436 @@
+// Copyright 2024 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "mediapipe/tasks/ios/audio/audio_Embedder/sources/MPPAudioEmbedder.h"
+#import "mediapipe/tasks/ios/common/sources/MPPCommon.h"
+#import "mediapipe/tasks/ios/common/utils/sources/NSString+Helpers.h"
+#import "mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioFile+TestUtils.h"
+#import "mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h"
+#import "mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.h"
+#import "mediapipe/tasks/ios/test/utils/sources/MPPFileInfo.h"
+
+static MPPFileInfo *const kYamnetModelFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"yamnet_embedding_metadata" type:@"tflite"];
+static MPPFileInfo *const kSpeech16KHzMonoFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"speech_16000_hz_mono" type:@"wav"];
+static MPPFileInfo *const kSpeech48KHzMonoFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"speech_48000_hz_mono" type:@"wav"];
+static MPPFileInfo *const kTwoHeads16KHzMonoFileInfo =
+    [[MPPFileInfo alloc] initWithName:@"two_heads_16000_hz_mono" type:@"wav"];
+
+static const NSInteger kYamnetSampleCount = 15600;
+static const double kYamnetSampleRate = 16000.0;
+static const NSInteger kExpectedEmbeddingLength = 1024;
+static const NSInteger kExpectedEmbeddingResultsCountForSpeechFiles = 5;
+
+static NSString *const kExpectedErrorDomain = @"com.google.mediapipe.tasks";
+static NSString *const kAudioStreamTestsDictEmbedderKey = @"audioEmbedder";
+static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
+
+#define AssertEqualErrors(error, expectedError)              \
+  XCTAssertNotNil(error);                                    \
+  XCTAssertEqualObjects(error.domain, expectedError.domain); \
+  XCTAssertEqual(error.code, expectedError.code);            \
+  XCTAssertEqualObjects(error.localizedDescription, expectedError.localizedDescription)
+
+#define AssertEmbeddingResultHasOneEmbedding(embeddingResult) \
+  XCTAssertNotNil(embeddingResult);                           \
+  \                                                          
+  XCTAssertEqual(embeddingResult.embeddings.count, 1);
+
+#define AssertEmbeddingHasCorrectTypeAndDimension(embedding, quantize, expectedLength) \
+  if (quantize) {                                                                      \
+    XCTAssertNil(embedding.floatEmbedding);                                            \
+    XCTAssertNotNil(embedding.quantizedEmbedding);                                     \
+    XCTAssertEqual(embedding.quantizedEmbedding.count, expectedLength);                \
+  } else {                                                                             \
+    XCTAssertNotNil(embedding.floatEmbedding);                                         \
+    XCTAssertNil(embedding.quantizedEmbedding);                                        \
+    XCTAssertEqual(embedding.floatEmbedding.count, expectedLength);                    \
+  }
+
+@interface MPPAudioEmbedderTests : XCTestCase <MPPAudioEmbedderStreamDelegate>
+@end
+
+@implementation MPPAudioEmbedderTests
+
+#pragma mark General Tests
+
+- (void)testCreateAudioEmbedderWithMissingModelPathFails {
+  MPPFileInfo *fileInfo = [[MPPFileInfo alloc] initWithName:@"" type:@""];
+
+  NSError *error = nil;
+  MPPAudioEmbedder *audioEmbedder = [[MPPAudioEmbedder alloc] initWithModelPath:fileInfo.path
+                                                                          error:&error];
+  XCTAssertNil(audioEmbedder);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey :
+                   @"INVALID_ARGUMENT: ExternalFile must specify at least one of 'file_content', "
+                   @"'file_name', 'file_pointer_meta' or 'file_descriptor_meta'."
+             }];
+  AssertEqualErrors(error, expectedError);
+}
+
+- (void)testEmbedWithModelPathAndDifferentAudioFilesSucceeds {
+  MPPAudioEmbedder *audioEmbedder =
+      [[MPPAudioEmbedder alloc] initWithModelPath:kYamnetModelFileInfo.path error:nil];
+  XCTAssertNotNil(audioEmbedder);
+
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:NO
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:NO
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+
+  const NSInteger expectedEmbeddingResultCount = 1;
+  [MPPAudioEmbedderTests assertResultsOfEmbedAudioClipWithFileInfo:kTwoHeads16KHzMonoFileInfo
+                                                usingAudioEmbedder:audioEmbedder
+                                                       isQuantized:NO
+                                     expectedEmbeddingResultsCount:expectedEmbeddingResultCount];
+}
+
+- (void)testEmbedWithOptionsSucceeds {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:options.quantize
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:options.quantize
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+}
+
+- (void)testEmbedWithQuantizationSucceeds {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  options.quantize = YES;
+
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  const NSInteger expectedEmbeddingResultsCount = 5;
+  [MPPAudioEmbedderTests assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                                                usingAudioEmbedder:audioEmbedder
+                                                       isQuantized:options.quantize
+                                     expectedEmbeddingResultsCount:expectedEmbeddingResultsCount];
+  [MPPAudioEmbedderTests assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                                                usingAudioEmbedder:audioEmbedder
+                                                       isQuantized:options.quantize
+                                     expectedEmbeddingResultsCount:expectedEmbeddingResultsCount];
+}
+
+- (void)testEmbedWithL2NormalizationSucceeds {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  options.l2Normalize = YES;
+
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:options.quantize
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:options.quantize
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+}
+
+- (void)testEmbedWithSilenceSucceeds {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  const NSInteger channelCount = 1;
+
+  MPPAudioData *audioData = [[MPPAudioData alloc] initWithChannelCount:channelCount
+                                                            sampleRate:kYamnetSampleRate
+                                                           sampleCount:kYamnetSampleCount];
+
+  MPPAudioEmbedderResult *result = [audioEmbedder embedAudioClip:audioData error:nil];
+  XCTAssertNotNil(result);
+
+  const NSInteger expectedClassificationResultsCount = 1;
+
+  [MPPAudioEmbedderTests assertAudioEmbedderResult:result
+                                       isQuantized:options.quantize
+                  hasExpectedEmbeddingResultsCount:expectedClassificationResultsCount
+                           expectedEmbeddingLength:kExpectedEmbeddingLength];
+}
+
+- (void)testEmbedAfterCloseFailsInAudioClipsMode {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  // Classify 16KHz speech file.
+  [MPPAudioEmbedderTests
+      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                             usingAudioEmbedder:audioEmbedder
+                                    isQuantized:options.quantize
+                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+
+  NSError *closeError;
+  XCTAssertTrue([audioEmbedder closeWithError:&closeError]);
+  XCTAssertNil(closeError);
+
+  const NSInteger channelCount = 1;
+  MPPAudioData *audioData = [[MPPAudioData alloc] initWithChannelCount:channelCount
+                                                            sampleRate:kYamnetSampleRate
+                                                           sampleCount:kYamnetSampleCount];
+
+  NSError *embedError;
+
+  [audioEmbedder embedAudioClip:audioData error:&embedError];
+
+  NSError *expectedEmbedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey : [NSString
+                   stringWithFormat:@"INVALID_ARGUMENT: Task runner is currently not running."]
+             }];
+
+  AssertEqualErrors(embedError, expectedEmbedError);
+}
+
+#pragma mark Running mode tests
+- (void)testCreateAudioEmbedderFailsWithDelegateInAudioClipsMode {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  options.audioEmbedderStreamDelegate = self;
+
+  [MPPAudioEmbedderTests
+      assertCreateAudioEmbedderWithOptions:options
+                    failsWithExpectedError:
+                        [NSError
+                            errorWithDomain:kExpectedErrorDomain
+                                       code:MPPTasksErrorCodeInvalidArgumentError
+                                   userInfo:@{
+                                     NSLocalizedDescriptionKey : [NSString
+                                         stringWithFormat:@"The audio task is in audio clips "
+                                                          @"mode. The delegate must not be set "
+                                                          @"in the task's options."]
+                                   }]];
+}
+
+- (void)testEmbedFailsWithCallingWrongApiInAudioClipsMode {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  MPPAudioData *audioClip = [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
+  NSError *error;
+  XCTAssertFalse([audioEmbedder embedAsyncAudioBlock:audioClip
+                             timestampInMilliseconds:0
+                                               error:&error]);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey :
+                   [NSString stringWithFormat:@"The audio task is not initialized with "
+                                              @"audio stream mode. Current Running Mode: %@",
+                                              MPPAudioRunningModeDisplayName(options.runningMode)]
+             }];
+  AssertEqualErrors(error, expectedError);
+}
+
+- (void)testEmbedFailsWithCallingWrongApiInAudioStreamMode {
+  MPPAudioEmbedderOptions *options =
+      [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
+  options.runningMode = MPPAudioRunningModeAudioStream;
+  options.audioEmbedderStreamDelegate = self;
+
+  MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
+
+  MPPAudioData *audioClip = [[MPPAudioData alloc] initWithFileInfo:kSpeech16KHzMonoFileInfo];
+
+  NSError *error;
+  XCTAssertFalse([audioEmbedder embedAudioClip:audioClip error:&error]);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey :
+                   [NSString stringWithFormat:@"The audio task is not initialized with "
+                                              @"audio clips. Current Running Mode: %@",
+                                              MPPAudioRunningModeDisplayName(options.runningMode)]
+             }];
+  AssertEqualErrors(error, expectedError);
+}
+
+#pragma mark Audio Record Tests
+
+- (void)testCreateAudioRecordSucceeds {
+  const NSUInteger channelCount = 1;
+  const NSUInteger bufferLength = channelCount * kYamnetSampleCount;
+
+  NSError *error;
+  MPPAudioRecord *audioRecord =
+      [MPPAudioEmbedder createAudioRecordWithChannelCount:channelCount
+                                               sampleRate:kYamnetSampleRate
+                                             bufferLength:kYamnetSampleCount * channelCount
+                                                    error:&error];
+
+  XCTAssertNotNil(audioRecord);
+  XCTAssertNil(error);
+  XCTAssertEqual(audioRecord.audioDataFormat.channelCount, channelCount);
+  XCTAssertEqual(audioRecord.audioDataFormat.sampleRate, kYamnetSampleRate);
+  XCTAssertEqual(audioRecord.bufferLength, bufferLength);
+}
+
+// Test for error propogation from audio record creation.
+- (void)testCreateAudioRecordWithInvalidChannelCountFails {
+  const NSUInteger channelCount = 3;
+
+  NSError *error;
+  MPPAudioRecord *audioRecord =
+      [MPPAudioEmbedder createAudioRecordWithChannelCount:channelCount
+                                               sampleRate:kYamnetSampleRate
+                                             bufferLength:kYamnetSampleCount * channelCount
+                                                    error:&error];
+  XCTAssertNil(audioRecord);
+
+  NSError *expectedError = [NSError
+      errorWithDomain:kExpectedErrorDomain
+                 code:MPPTasksErrorCodeInvalidArgumentError
+             userInfo:@{
+               NSLocalizedDescriptionKey : @"The channel count provided does not match the "
+                                           @"supported channel count. Only channels counts "
+                                           @"in the range [1 : 2] are supported"
+             }];
+
+  AssertEqualErrors(error, expectedError);
+}
+
+#pragma mark MPPAudioEmbedderrStreamDelegate
+
+- (void)audioEmbedder:(MPPAudioEmbedder *)audioEmbedder
+    didFinishEmbeddingWithResult:(MPPAudioEmbedderResult *)result
+         timestampInMilliseconds:(NSInteger)timestampInMilliseconds
+                           error:(NSError *)error {
+  // TODO: Test for results when stream mode inference tests are added.
+}
+
+#pragma mark Audio Data Initializers
+
++ (NSArray<MPPTimestampedAudioData *> *)streamedAudioDataListforYamnet {
+  NSArray<MPPTimestampedAudioData *> *streamedAudioDataList =
+      [AVAudioFile streamedAudioBlocksFromAudioFileWithInfo:kSpeech16KHzMonoFileInfo
+                                           modelSampleCount:kYamnetSampleCount
+                                            modelSampleRate:kYamnetSampleRate];
+
+  XCTAssertEqual(streamedAudioDataList.count, 5);
+
+  return streamedAudioDataList;
+}
+
+#pragma mark Audio Embedder Initializers
+
++ (MPPAudioEmbedderOptions *)audioEmbedderOptionsWithModelFileInfo:(MPPFileInfo *)modelFileInfo {
+  MPPAudioEmbedderOptions *options = [[MPPAudioEmbedderOptions alloc] init];
+  options.baseOptions.modelAssetPath = modelFileInfo.path;
+
+  return options;
+}
+
++ (MPPAudioEmbedder *)audioEmbedderWithOptions:(MPPAudioEmbedderOptions *)options {
+  NSError *error;
+  MPPAudioEmbedder *audioEmbedder = [[MPPAudioEmbedder alloc] initWithOptions:options error:&error];
+  XCTAssertNotNil(audioEmbedder);
+  XCTAssertNil(error);
+
+  return audioEmbedder;
+}
+
++ (MPPAudioEmbedder *)createAudioEmbedderWithOptionsSucceeds:
+    (MPPAudioEmbedderOptions *)audioEmbedderOptions {
+  NSError *error;
+  MPPAudioEmbedder *audioEmbedder = [[MPPAudioEmbedder alloc] initWithOptions:audioEmbedderOptions
+                                                                        error:&error];
+  XCTAssertNotNil(audioEmbedder);
+  XCTAssertNil(error);
+
+  return audioEmbedder;
+}
+
++ (void)assertCreateAudioEmbedderWithOptions:(MPPAudioEmbedderOptions *)options
+                      failsWithExpectedError:(NSError *)expectedError {
+  NSError *error = nil;
+  MPPAudioEmbedder *audioEmbedder = [[MPPAudioEmbedder alloc] initWithOptions:options error:&error];
+
+  XCTAssertNil(audioEmbedder);
+  AssertEqualErrors(error, expectedError);
+}
+
+#pragma mark Results
+
++ (void)assertResultsOfEmbedAudioClipWithFileInfo:(MPPFileInfo *)fileInfo
+                               usingAudioEmbedder:(MPPAudioEmbedder *)audioEmbedder
+                                      isQuantized:(BOOL)isQuantized
+                    expectedEmbeddingResultsCount:(NSInteger)expectedEmbeddingResultsCount {
+  MPPAudioEmbedderResult *result = [MPPAudioEmbedderTests embedAudioClipWithFileInfo:fileInfo
+                                                                  usingAudioEmbedder:audioEmbedder];
+
+  [MPPAudioEmbedderTests assertAudioEmbedderResult:result
+                                       isQuantized:isQuantized
+                  hasExpectedEmbeddingResultsCount:expectedEmbeddingResultsCount
+                           expectedEmbeddingLength:kExpectedEmbeddingLength];
+}
+
++ (void)assertAudioEmbedderResult:(MPPAudioEmbedderResult *)result
+                         isQuantized:(BOOL)isQuantized
+    hasExpectedEmbeddingResultsCount:(NSInteger)expectedEmbeddingResultsCount
+             expectedEmbeddingLength:(NSInteger)expectedEmbeddingLength {
+  XCTAssertEqual(result.embeddingResults.count, expectedEmbeddingResultsCount);
+  for (MPPEmbeddingResult *embeddingResult in result.embeddingResults) {
+    AssertEmbeddingResultHasOneEmbedding(embeddingResult);
+    AssertEmbeddingHasCorrectTypeAndDimension(embeddingResult.embeddings[0], isQuantized,
+                                              expectedEmbeddingLength);
+  }
+}
+
++ (MPPAudioEmbedderResult *)embedAudioClipWithFileInfo:(MPPFileInfo *)fileInfo
+                                    usingAudioEmbedder:(MPPAudioEmbedder *)audioEmbedder {
+  MPPAudioData *audioData = [[MPPAudioData alloc] initWithFileInfo:fileInfo];
+  MPPAudioEmbedderResult *result = [audioEmbedder embedAudioClip:audioData error:nil];
+  XCTAssertNotNil(result);
+
+  return result;
+}
+
+@end

--- a/mediapipe/tasks/ios/test/audio/audio_embedder/MPPAudioEmbedderTests.mm
+++ b/mediapipe/tasks/ios/test/audio/audio_embedder/MPPAudioEmbedderTests.mm
@@ -48,7 +48,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 #define AssertEmbeddingResultHasOneEmbedding(embeddingResult) \
   XCTAssertNotNil(embeddingResult);                           \
-  \                                                          
+  \                                                         
   XCTAssertEqual(embeddingResult.embeddings.count, 1);
 
 #define AssertEmbeddingHasCorrectTypeAndDimension(embedding, quantize, expectedLength) \
@@ -94,21 +94,21 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   XCTAssertNotNil(audioEmbedder);
 
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:NO
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:NO
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
 
   const NSInteger expectedEmbeddingResultCount = 1;
-  [MPPAudioEmbedderTests assertResultsOfEmbedAudioClipWithFileInfo:kTwoHeads16KHzMonoFileInfo
-                                                usingAudioEmbedder:audioEmbedder
-                                                       isQuantized:NO
-                                     expectedEmbeddingResultsCount:expectedEmbeddingResultCount];
+  [MPPAudioEmbedderTests
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kTwoHeads16KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:expectedEmbeddingResultCount];
 }
 
 - (void)testEmbedWithOptionsSucceeds {
@@ -118,15 +118,15 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
 
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:options.quantize
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:options.quantize
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
 }
 
 - (void)testEmbedWithQuantizationSucceeds {
@@ -155,15 +155,15 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   MPPAudioEmbedder *audioEmbedder = [MPPAudioEmbedderTests audioEmbedderWithOptions:options];
 
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:options.quantize
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech16KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
   [MPPAudioEmbedderTests
-      assertResultsOfEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
-                             usingAudioEmbedder:audioEmbedder
-                                    isQuantized:options.quantize
-                  expectedEmbeddingResultsCount:kExpectedEmbeddingResultsCountForSpeechFiles];
+      assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:kSpeech48KHzMonoFileInfo
+                                         usingAudioEmbedder:audioEmbedder
+                              expectedEmbeddingResultsCount:
+                                  kExpectedEmbeddingResultsCountForSpeechFiles];
 }
 
 - (void)testEmbedWithSilenceSucceeds {
@@ -180,11 +180,10 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   MPPAudioEmbedderResult *result = [audioEmbedder embedAudioClip:audioData error:nil];
   XCTAssertNotNil(result);
 
-  const NSInteger expectedClassificationResultsCount = 1;
-
+  const NSInteger expectedEmbedderResultsCount = 1;
   [MPPAudioEmbedderTests assertAudioEmbedderResult:result
                                        isQuantized:options.quantize
-                  hasExpectedEmbeddingResultsCount:expectedClassificationResultsCount
+                     expectedEmbeddingResultsCount:expectedEmbedderResultsCount
                            expectedEmbeddingLength:kExpectedEmbeddingLength];
 }
 
@@ -225,6 +224,7 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 }
 
 #pragma mark Running mode tests
+
 - (void)testCreateAudioEmbedderFailsWithDelegateInAudioClipsMode {
   MPPAudioEmbedderOptions *options =
       [MPPAudioEmbedderTests audioEmbedderOptionsWithModelFileInfo:kYamnetModelFileInfo];
@@ -337,26 +337,13 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
   AssertEqualErrors(error, expectedError);
 }
 
-#pragma mark MPPAudioEmbedderrStreamDelegate
+#pragma mark MPPAudioEmbedderStreamDelegate
 
 - (void)audioEmbedder:(MPPAudioEmbedder *)audioEmbedder
     didFinishEmbeddingWithResult:(MPPAudioEmbedderResult *)result
          timestampInMilliseconds:(NSInteger)timestampInMilliseconds
                            error:(NSError *)error {
-  // TODO: Test for results when stream mode inference tests are added.
-}
-
-#pragma mark Audio Data Initializers
-
-+ (NSArray<MPPTimestampedAudioData *> *)streamedAudioDataListforYamnet {
-  NSArray<MPPTimestampedAudioData *> *streamedAudioDataList =
-      [AVAudioFile streamedAudioBlocksFromAudioFileWithInfo:kSpeech16KHzMonoFileInfo
-                                           modelSampleCount:kYamnetSampleCount
-                                            modelSampleRate:kYamnetSampleRate];
-
-  XCTAssertEqual(streamedAudioDataList.count, 5);
-
-  return streamedAudioDataList;
+  // TODO: Add assertion for the result when stream mode inference tests are added.
 }
 
 #pragma mark Audio Embedder Initializers
@@ -399,6 +386,16 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
 #pragma mark Results
 
++ (void)assertResultsOfNonQuantizedEmbedAudioClipWithFileInfo:(MPPFileInfo *)fileInfo
+                                           usingAudioEmbedder:(MPPAudioEmbedder *)audioEmbedder
+                                expectedEmbeddingResultsCount:
+                                    (NSInteger)expectedEmbeddingResultsCount {
+  [MPPAudioEmbedderTests assertResultsOfEmbedAudioClipWithFileInfo:fileInfo
+                                                usingAudioEmbedder:audioEmbedder
+                                                       isQuantized:NO
+                                     expectedEmbeddingResultsCount:expectedEmbeddingResultsCount];
+}
+
 + (void)assertResultsOfEmbedAudioClipWithFileInfo:(MPPFileInfo *)fileInfo
                                usingAudioEmbedder:(MPPAudioEmbedder *)audioEmbedder
                                       isQuantized:(BOOL)isQuantized
@@ -408,14 +405,14 @@ static NSString *const kAudioStreamTestsDictExpectationKey = @"expectation";
 
   [MPPAudioEmbedderTests assertAudioEmbedderResult:result
                                        isQuantized:isQuantized
-                  hasExpectedEmbeddingResultsCount:expectedEmbeddingResultsCount
+                     expectedEmbeddingResultsCount:expectedEmbeddingResultsCount
                            expectedEmbeddingLength:kExpectedEmbeddingLength];
 }
 
 + (void)assertAudioEmbedderResult:(MPPAudioEmbedderResult *)result
-                         isQuantized:(BOOL)isQuantized
-    hasExpectedEmbeddingResultsCount:(NSInteger)expectedEmbeddingResultsCount
-             expectedEmbeddingLength:(NSInteger)expectedEmbeddingLength {
+                      isQuantized:(BOOL)isQuantized
+    expectedEmbeddingResultsCount:(NSInteger)expectedEmbeddingResultsCount
+          expectedEmbeddingLength:(NSInteger)expectedEmbeddingLength {
   XCTAssertEqual(result.embeddingResults.count, expectedEmbeddingResultsCount);
   for (MPPEmbeddingResult *embeddingResult in result.embeddingResults) {
     AssertEmbeddingResultHasOneEmbedding(embeddingResult);

--- a/mediapipe/tasks/ios/test/audio/core/utils/BUILD
+++ b/mediapipe/tasks/ios/test/audio/core/utils/BUILD
@@ -48,7 +48,7 @@ objc_library(
     hdrs = ["sources/MPPAudioData+TestUtils.h"],
     deps = [
         ":AVAudioPCMBufferTestUtils",
-        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
         "//mediapipe/tasks/ios/audio/core:MPPAudioData",
+        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
     ],
 )

--- a/mediapipe/tasks/ios/test/audio/core/utils/BUILD
+++ b/mediapipe/tasks/ios/test/audio/core/utils/BUILD
@@ -47,6 +47,8 @@ objc_library(
     srcs = ["sources/MPPAudioData+TestUtils.m"],
     hdrs = ["sources/MPPAudioData+TestUtils.h"],
     deps = [
+        ":AVAudioPCMBufferTestUtils",
+        "//mediapipe/tasks/ios/test/utils:MPPFileInfo",
         "//mediapipe/tasks/ios/audio/core:MPPAudioData",
     ],
 )

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.h
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.h
@@ -14,6 +14,7 @@
 
 #import <Foundation/Foundation.h>
 #import "mediapipe/tasks/ios/audio/core/sources/MPPAudioData.h"
+#import "mediapipe/tasks/ios/test/utils/sources/MPPFileInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -33,6 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
                           sampleRate:(double)sampleRate
                          sampleCount:(NSUInteger)sampleCount;
 
+/**
+ * Creats an `MPPAudioData` and loads it with samples from an audio file specified by `fileInfo`.
+ *
+ * @param fileInfo `MPPFileInfo` with name and type of the audio file stored in the bundle.
+ *
+ * @return The `MPPAudioData` object loaded with samples from the input audio file.
+ */
+- (instancetype)initWithFileInfo:(MPPFileInfo *)fileInfo;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.m
+++ b/mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "mediapipe/tasks/ios/test/audio/core/utils/sources/AVAudioPCMBuffer+TestUtils.h"
 #import "mediapipe/tasks/ios/test/audio/core/utils/sources/MPPAudioData+TestUtils.h"
 
 @implementation MPPAudioData (TestUtils)
@@ -22,6 +23,26 @@
   MPPAudioDataFormat *audioDataFormat =
       [[MPPAudioDataFormat alloc] initWithChannelCount:channelCount sampleRate:sampleRate];
   return [self initWithFormat:audioDataFormat sampleCount:sampleCount];
+}
+
+- (instancetype)initWithFileInfo:(MPPFileInfo *)fileInfo {
+  // Load the samples from the audio file in `Float32` interleaved format to
+  // an `AVAudioPCMBuffer`.
+  AVAudioPCMBuffer *buffer =
+      [AVAudioPCMBuffer interleavedFloat32BufferFromAudioFileWithInfo:fileInfo];
+
+  // Create a float buffer from the `floatChannelData` of `AVAudioPCMBuffer`. This float buffer will
+  // be used to load the audio data.
+  MPPFloatBuffer *bufferData = [[MPPFloatBuffer alloc] initWithData:buffer.floatChannelData[0]
+                                                             length:buffer.frameLength];
+
+  MPPAudioData *audioData = [self initWithChannelCount:buffer.format.channelCount
+                                            sampleRate:buffer.format.sampleRate
+                                           sampleCount:buffer.frameLength];
+
+  // Load all the samples in the audio file to the newly created audio data.
+  [audioData loadBuffer:bufferData offset:0 length:bufferData.length error:nil];
+  return audioData;
 }
 
 @end


### PR DESCRIPTION
1. Added clips mode tests for iOS audio embedder
2. Fixed audio embedder result parsing, disable flow limiting, added close method.
3. Added a new method to MPPAudioData test utils and updated audio classifier tests to use the same.