### PR TITLE
When compiling on Windows using MSVC, this section of code caused a c…

### DIFF
--- a/mediapipe/tasks/cc/core/task_api_factory.h
+++ b/mediapipe/tasks/cc/core/task_api_factory.h
@@ -76,15 +76,17 @@ class TaskApiFactory {
         found_task_subgraph = true;
       }
     }
+#if !MEDIAPIPE_DISABLE_GPU
     MP_ASSIGN_OR_RETURN(
         auto runner,
-#if !MEDIAPIPE_DISABLE_GPU
         core::TaskRunner::Create(std::move(graph_config), std::move(resolver),
                                  std::move(packets_callback),
                                  std::move(default_executor),
                                  std::move(input_side_packets),
                                  /*resources=*/nullptr, std::move(error_fn)));
 #else
+    MP_ASSIGN_OR_RETURN(
+        auto runner,
         core::TaskRunner::Create(
             std::move(graph_config), std::move(resolver),
             std::move(packets_callback), std::move(default_executor),


### PR DESCRIPTION
When compiling on Windows using MSVC, this section of code caused a compilation error due to macro expansion issues. I modified the code to fix this, and now it compiles successfully.