### PR TITLE
Update base_options.py Fix Windows Path Concatenation Issue with mode…

### DIFF
--- a/mediapipe/tasks/python/core/base_options.py
+++ b/mediapipe/tasks/python/core/base_options.py
@@ -80,7 +80,15 @@ class BaseOptions:
       acceleration_proto = _AccelerationProto(tflite=_DelegateProto.TfLite())
     else:
       acceleration_proto = None
-
+    
+    if platform_name == 'Windows' and full_path is not None:
+      try:
+        with open(full_path, "rb") as f:
+          self.model_asset_buffer = f.read()
+          self.model_asset_path = None
+      except FileNotFoundError:
+        raise RuntimeError(f"Unable to open file at {full_path}.")
+    
     return _BaseOptionsProto(
         model_asset=_ExternalFileProto(
             file_name=full_path, file_content=self.model_asset_buffer


### PR DESCRIPTION
**Summary**:
This PR addresses a bug in MediaPipe on Windows where specifying model_asset_path for MediaPipe tasks (such as FaceLandmarker) results in an invalid path concatenation. This error does not appear on Linux or macOS and occurs specifically when _TaskRunner concatenates the absolute model_asset_path with default internal paths, leading to issues such as errno=22 due to an invalid file path.

**Issue Description**: 
When BaseOptions.model_asset_path is used on Windows, the underlying _TaskRunner component incorrectly concatenates the provided path with a directory in site-packages, leading to an inaccessible or incorrect path. This results in the error:

```RuntimeError: Unable to open file at C:\Users\...\site-packages/C:\Users\...\face_landmarker.task, errno=22```


The error occurs only on Windows, likely due to platform-specific handling of absolute paths.

**Proposed Solution**:
1) Detecting the Windows platform.
2) Attempting to load the model file directly into model_asset_buffer if model_asset_path is provided. 
3) Setting model_asset_path to None if the model is successfully loaded into model_asset_buffer, bypassing the problematic path concatenation in _TaskRunner.