### PR TITLE
Update requirements.txt to allow Numpy 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flatbuffers>=2.0
 jax
 jaxlib
 matplotlib
-numpy<2
+numpy<2.1
 opencv-contrib-python
 protobuf>=4.25.3,<5
 sounddevice>=0.4.4


### PR DESCRIPTION
allow Numpy 2.0.2 since 1.26.4 is becoming increasingly outdated leading to dependency conflicts with newer versions of pytorch.