### PR TITLE
Ensure thread pool has at least 2 threads when profiling is enabled

### DIFF
--- a/mediapipe/framework/calculator_graph.cc
+++ b/mediapipe/framework/calculator_graph.cc
@@ -431,6 +431,13 @@ absl::Status CalculatorGraph::InitializeDefaultExecutor(
         std::max({validated_graph_->Config().node().size(),
                   validated_graph_->Config().packet_generator().size(), 1}));
   }
+#ifdef MEDIAPIPE_PROFILER_AVAILABLE
+  // Ensure that the thread pool has at least 2 threads when profiling is enabled.
+  // This is necessary because the PROFILING function relies on the thread pool 
+  // for its operations, and having only 1 thread may lead to contention, 
+  // preventing the Calculator's Process function from being scheduled.
+  num_threads = std::max(num_threads, 2);
+#endif
   MP_RETURN_IF_ERROR(
       CreateDefaultThreadPool(default_executor_options, num_threads));
   VLOG(1) << absl::StrCat("Using default executor with num_threads: ",


### PR DESCRIPTION
When the PROFILING feature is enabled, the profiler relies on the thread pool for its operations. If the thread pool is configured with only 1 thread, it can lead to resource contention, preventing the Calculator's Process function from being scheduled.

This commit ensures that the thread pool size is set to at least 2 threads when profiling is available, avoiding potential scheduling issues.

Relevant code change:
  - Added a check to guarantee `num_threads` is at least 2 under `MEDIAPIPE_PROFILER_AVAILABLE`.

Fixes potential issues with single-threaded configurations under profiling.