### PR TITLE
fix web demo url

### DIFF
--- a/docs/solutions/pose.md
+++ b/docs/solutions/pose.md
@@ -497,7 +497,7 @@ on how to build MediaPipe examples.
     ([presentation](https://youtu.be/YPpUOTRn5tA))
 *   [Models and model cards](./models.md#pose)
 *   [GHUM & GHUML: Generative 3D Human Shape and Articulated Pose Models](https://github.com/google-research/google-research/tree/master/ghum)
-*   [Web demo](https://code.mediapipe.dev/codepen/pose)
+*   [Web demo](https://codepen.io/mediapipe/pen/LYRRYEw)
 *   [Python Colab](https://mediapipe.page.link/pose_py_colab)
 
 [`mAP`]: https://cocodataset.org/#keypoints-eval


### PR DESCRIPTION
### Description:

Currently `Web Demo` link redirects to `https://code.mediapipe.dev/codepen/pose` which is 404.
I've changed it to `https://codepen.io/mediapipe/pen/LYRRYEw` which seems to be the actual Web Demo example.
<img width="939" alt="Screenshot 2025-01-12 at 21 03 24" src="https://github.com/user-attachments/assets/90792efc-d756-460c-817d-069e02a23091" />
