### PR TITLE
Fix Typos and Type Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ iOS), web, desktop, edge devices, and IoT, effortlessly.
 
 ## Get started
 
-You can get started with MediaPipe Solutions by by checking out any of the
+You can get started with MediaPipe Solutions by checking out any of the
 developer guides for
 [vision](https://developers.google.com/mediapipe/solutions/vision/object_detector),
 [text](https://developers.google.com/mediapipe/solutions/text/text_classifier),

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ iOS), web, desktop, edge devices, and IoT, effortlessly.
 
 ## Get started
 
-You can get started with MediaPipe Solutions by by checking out any of the
+You can get started with MediaPipe Solutions by checking out any of the
 developer guides for
 [vision](https://developers.google.com/mediapipe/solutions/vision/object_detector),
 [text](https://developers.google.com/mediapipe/solutions/text/text_classifier),

--- a/mediapipe/python/pybind/calculator_graph.cc
+++ b/mediapipe/python/pybind/calculator_graph.cc
@@ -125,7 +125,7 @@ void CalculatorGraphSubmodule(pybind11::module* module) {
 
   Raises:
     FileNotFoundError: If the binary graph file can't be found.
-    ValueError: If the input arguments prvoided are more than needed or the
+    ValueError: If the input arguments provided are more than needed or the
       graph validation process contains error.
 )doc");
 
@@ -202,7 +202,7 @@ void CalculatorGraphSubmodule(pybind11::module* module) {
     graph.add_packet_to_input_stream(
         stream='in',
         packet=packet_creator.create_string('hello world'),
-        timstamp=1)
+        timestamp=1)
 )doc",
       py::arg("stream"), py::arg("packet"),
       py::arg("timestamp") = Timestamp::Unset());
@@ -461,7 +461,7 @@ void CalculatorGraphSubmodule(pybind11::module* module) {
       R"doc(Get output side packet by name after the graph is done.
 
   Args:
-    stream: The name of the outnput stream.
+    stream: The name of the output stream.
 
   Raises:
     RuntimeError: If the graph is still running or the output side packet is not

--- a/mediapipe/python/pybind/packet_creator.cc
+++ b/mediapipe/python/pybind/packet_creator.cc
@@ -377,7 +377,7 @@ void PublicPacketCreators(pybind11::module* m) {
     A MediaPipe double Packet.
 
   Raises:
-    TypeError: If the input is neither a float nore a np.double.
+    TypeError: If the input is neither a float nor a np.double.
 
   Examples:
     packet = mp.packet_creator.create_double(0.1)
@@ -702,7 +702,7 @@ void InternalPacketCreators(pybind11::module* m) {
         // TODO: Implement this.
         throw RaisePyError(PyExc_NotImplementedError,
                            "Creating a packet from a vector of proto messages "
-                           "is not supproted yet.");
+                           "is not supported yet.");
         return Packet();
       },
       py::return_value_policy::move);

--- a/mediapipe/python/pybind/packet_getter.cc
+++ b/mediapipe/python/pybind/packet_getter.cc
@@ -458,7 +458,7 @@ void InternalPacketGetters(pybind11::module* m) {
         // https://github.com/pybind/pybind11/issues/1236
         // However, when Pybind11 performs the C++ to Python transition, it
         // only increases the py::bytes object's ref count. See the
-        // implmentation at line 1583 in "pybind11/cast.h".
+        // implementation at line 1583 in "pybind11/cast.h".
         return py::bytes(packet.GetProtoMessageLite().SerializeAsString());
       },
       py::return_value_policy::move);

--- a/mediapipe/python/pybind/util.h
+++ b/mediapipe/python/pybind/util.h
@@ -67,7 +67,7 @@ inline void RaisePyErrorIfNotOk(const absl::Status& status,
 inline void RaisePyErrorIfOverflow(int64_t value, int64_t min, int64_t max) {
   if (value > max) {
     throw RaisePyError(PyExc_OverflowError,
-                       absl::StrCat(value, " execeeds the maximum value (", max,
+                       absl::StrCat(value, " exceeds the maximum value (", max,
                                     ") the data type can have.")
                            .c_str());
   } else if (value < min) {

--- a/mediapipe/python/pybind/validated_graph_config.cc
+++ b/mediapipe/python/pybind/validated_graph_config.cc
@@ -84,7 +84,7 @@ void ValidatedGraphConfigSubmodule(pybind11::module* module) {
 
   Raises:
     FileNotFoundError: If the binary graph file can't be found.
-    ValueError: If the input arguments prvoided are more than needed or the
+    ValueError: If the input arguments provided are more than needed or the
       graph validation process contains error.
 
   Examples:

--- a/mediapipe/tasks/cc/core/model_resources.h
+++ b/mediapipe/tasks/cc/core/model_resources.h
@@ -66,7 +66,7 @@ class ModelResources {
   // Takes the ownership of the provided ExternalFile proto and creates
   // ModelResources from the proto and an op resolver mediapipe packet. A
   // non-empty tag must be set if the ModelResources will be used through
-  // ModelResourcesCacheService. The op resolver packet, usually prvoided by a
+  // ModelResourcesCacheService. The op resolver packet, usually provided by a
   // ModelResourcesCacheService object, contains the TFLite op resolvers
   // required by the model.
   static absl::StatusOr<std::unique_ptr<ModelResources>> Create(

--- a/mediapipe/tasks/cc/vision/image_embedder/image_embedder.h
+++ b/mediapipe/tasks/cc/vision/image_embedder/image_embedder.h
@@ -156,7 +156,7 @@ class ImageEmbedder : core::BaseVisionTaskApi {
   // sent to the object detector. The input timestamps must be monotonically
   // increasing.
   //
-  // The "result_callback" prvoides
+  // The "result_callback" provides
   //   - The embedding results as a
   //     components::containers::proto::EmbeddingResult object.
   //   - The const reference to the corresponding input image that the image

--- a/mediapipe/tasks/python/audio/__init__.py
+++ b/mediapipe/tasks/python/audio/__init__.py
@@ -14,9 +14,9 @@
 
 """MediaPipe Tasks Audio API."""
 
-import mediapipe.tasks.python.audio.core
-import mediapipe.tasks.python.audio.audio_classifier
-import mediapipe.tasks.python.audio.audio_embedder
+import mediapipe.tasks.python.audio.core.audio_task_running_mode as audio_task_running_mode
+import mediapipe.tasks.python.audio.audio_classifier as audio_classifier
+import mediapipe.tasks.python.audio.audio_embedder as audio_embedder
 
 AudioClassifier = audio_classifier.AudioClassifier
 AudioClassifierOptions = audio_classifier.AudioClassifierOptions
@@ -24,10 +24,9 @@ AudioClassifierResult = audio_classifier.AudioClassifierResult
 AudioEmbedder = audio_embedder.AudioEmbedder
 AudioEmbedderOptions = audio_embedder.AudioEmbedderOptions
 AudioEmbedderResult = audio_embedder.AudioEmbedderResult
-RunningMode = core.audio_task_running_mode.AudioTaskRunningMode
+RunningMode = audio_task_running_mode.AudioTaskRunningMode
 
 # Remove unnecessary modules to avoid duplication in API docs.
 del audio_classifier
 del audio_embedder
-del core
-del mediapipe
+del audio_task_running_mode

--- a/mediapipe/tasks/python/audio/audio_classifier.py
+++ b/mediapipe/tasks/python/audio/audio_classifier.py
@@ -281,7 +281,7 @@ class AudioClassifier(base_audio_task_api.BaseAudioTaskApi):
     for adjacent calls of this method. This method will return immediately after
     the input audio data is accepted. The results will be available via the
     `result_callback` provided in the `AudioClassifierOptions`. The
-    `classify_async` method is designed to process auido stream data such as
+    `classify_async` method is designed to process audio stream data such as
     microphone input.
 
     The input audio data may be longer than what the model is able to process

--- a/mediapipe/tasks/python/audio/audio_embedder.py
+++ b/mediapipe/tasks/python/audio/audio_embedder.py
@@ -242,7 +242,7 @@ class AudioEmbedder(base_audio_task_api.BaseAudioTaskApi):
     for adjacent calls of this method. This method will return immediately after
     the input audio data is accepted. The results will be available via the
     `result_callback` provided in the `AudioEmbedderOptions`. The
-    `embed_async` method is designed to process auido stream data such as
+    `embed_async` method is designed to process audio stream data such as
     microphone input.
 
     The input audio data may be longer than what the model is able to process

--- a/mediapipe/tasks/python/audio/core/base_audio_task_api.py
+++ b/mediapipe/tasks/python/audio/core/base_audio_task_api.py
@@ -64,7 +64,7 @@ class BaseAudioTaskApi(object):
           'callback should not be provided.')
     self._runner = _TaskRunner.create(graph_config, packet_callback)
     self._running_mode = running_mode
-    self._default_sample_rate = None
+    self._default_sample_rate: Optional[float] = None
 
   def _process_audio_clip(
       self, inputs: Mapping[str, _Packet]) -> Mapping[str, _Packet]:
@@ -142,7 +142,7 @@ class BaseAudioTaskApi(object):
 
     Note that MediaPipe Audio tasks will up/down sample automatically to fit the
     sample rate required by the model. The default sample rate of the MediaPipe
-    pretrained audio model, Yamnet is 16kHz.
+    pretrained audio model, YAMNet is 16kHz.
 
     Args:
       num_channels: The number of audio channels.

--- a/mediapipe/tasks/python/benchmark/benchmark_utils.py
+++ b/mediapipe/tasks/python/benchmark/benchmark_utils.py
@@ -43,7 +43,7 @@ def get_test_data_path(test_srcdir, file_or_dirname_path: str) -> str:
       if path.endswith(file_or_dirname_path):
         return path
   raise ValueError(
-      "No %s in test directory: %s." % (file_or_dirname_path, test_srcdir)
+      f"No {file_or_dirname_path} in test directory: {test_srcdir}."
   )
 
 
@@ -57,14 +57,14 @@ def get_model_path(custom_model, default_model_path):
   Returns:
       The path to the model to be used.
   """
-  if custom_model is not None and os.path.exists(custom_model):
-    print(f"Using provided model: {custom_model}")
-    return custom_model
-  else:
-    if custom_model is not None:
-      print(
-          f"Warning: Provided model '{custom_model}' not found. "
-          "Using default model instead."
-      )
-    print(f"Using default model: {default_model_path}")
-    return default_model_path
+  if custom_model is not None:
+    if os.path.exists(custom_model):
+      print(f"Using provided model: {custom_model}")
+      return custom_model
+    print(
+        f"Warning: Provided model '{custom_model}' not found. "
+        "Using default model instead."
+    )
+
+  print(f"Using default model: {default_model_path}")
+  return default_model_path

--- a/mediapipe/tasks/python/components/containers/__init__.py
+++ b/mediapipe/tasks/python/components/containers/__init__.py
@@ -14,15 +14,15 @@
 
 """MediaPipe Tasks Components Containers API."""
 
-import mediapipe.tasks.python.components.containers.audio_data
-import mediapipe.tasks.python.components.containers.bounding_box
-import mediapipe.tasks.python.components.containers.category
-import mediapipe.tasks.python.components.containers.classification_result
-import mediapipe.tasks.python.components.containers.detections
-import mediapipe.tasks.python.components.containers.embedding_result
-import mediapipe.tasks.python.components.containers.landmark
-import mediapipe.tasks.python.components.containers.landmark_detection_result
-import mediapipe.tasks.python.components.containers.rect
+import mediapipe.tasks.python.components.containers.audio_data as audio_data
+import mediapipe.tasks.python.components.containers.bounding_box as bounding_box
+import mediapipe.tasks.python.components.containers.category as category
+import mediapipe.tasks.python.components.containers.classification_result as classification_result
+import mediapipe.tasks.python.components.containers.detections as detections
+import mediapipe.tasks.python.components.containers.embedding_result as embedding_result
+import mediapipe.tasks.python.components.containers.landmark as landmark
+import mediapipe.tasks.python.components.containers.landmark_detection_result as landmark_detection_result
+import mediapipe.tasks.python.components.containers.rect as rect
 
 AudioDataFormat = audio_data.AudioDataFormat
 AudioData = audio_data.AudioData
@@ -50,4 +50,3 @@ del embedding_result
 del landmark
 del landmark_detection_result
 del rect
-del mediapipe

--- a/mediapipe/tasks/python/components/processors/__init__.py
+++ b/mediapipe/tasks/python/components/processors/__init__.py
@@ -14,10 +14,9 @@
 
 """MediaPipe Tasks Components Processors API."""
 
-import mediapipe.tasks.python.components.processors.classifier_options
+import mediapipe.tasks.python.components.processors.classifier_options as classifier_options
 
 ClassifierOptions = classifier_options.ClassifierOptions
 
 # Remove unnecessary modules to avoid duplication in API docs.
 del classifier_options
-del mediapipe

--- a/mediapipe/tasks/python/components/utils/cosine_similarity.py
+++ b/mediapipe/tasks/python/components/utils/cosine_similarity.py
@@ -24,7 +24,7 @@ def _compute_cosine_similarity(u: np.ndarray, v: np.ndarray):
   """Computes cosine similarity between two embeddings."""
 
   if len(u) <= 0:
-    raise ValueError("Cannot compute cosing similarity on empty embeddings.")
+    raise ValueError("Cannot compute cosine similarity on empty embeddings.")
 
   norm_u = np.linalg.norm(u)
   norm_v = np.linalg.norm(v)

--- a/mediapipe/tasks/python/core/pybind/task_runner.cc
+++ b/mediapipe/tasks/python/core/pybind/task_runner.cc
@@ -82,7 +82,7 @@ mode) or not (synchronous mode).)doc");
 #if !MEDIAPIPE_DISABLE_GPU
         auto gpu_resources_ = mediapipe::GpuResources::Create();
         if (!gpu_resources_.ok()) {
-          ABSL_LOG(INFO) << "GPU suport is not available: "
+          ABSL_LOG(INFO) << "GPU support is not available: "
                          << gpu_resources_.status();
           gpu_resources_ = nullptr;
         }
@@ -91,7 +91,7 @@ mode) or not (synchronous mode).)doc");
             absl::make_unique<core::MediaPipeBuiltinOpResolver>(),
             std::move(callback),
             /* default_executor= */ nullptr,
-            /* input_side_packes= */ std::nullopt, std::move(*gpu_resources_));
+            /* input_side_packets= */ std::nullopt, std::move(*gpu_resources_));
 #else
         auto task_runner = TaskRunner::Create(
             std::move(graph_config),
@@ -117,7 +117,7 @@ Args:
 Raises:
   RuntimeError: Any of the following:
     a) The graph config proto is invalid.
-    b) The underlying medipaipe graph fails to initialize and start.
+    b) The underlying mediapipe graph fails to initialize and start.
 )doc",
       py::arg("graph_config"), py::arg("packets_callback") = py::none());
 
@@ -155,7 +155,7 @@ Raises:
   RuntimeError: Any of the following:
     a) TaskRunner is in the asynchronous mode (the packets callback is set).
     b) Any input stream name is not valid.
-    c) The underlying medipaipe graph occurs any error during this call.
+    c) The underlying mediapipe graph occurs any error during this call.
 )doc",
       py::arg("input_packets"));
 
@@ -191,7 +191,7 @@ Raises:
        queue size or the wrong packet type.
     d) The timestamp of any packet is invalid or is not greater than the
        previously received timestamps.
-    e) The underlying medipaipe graph occurs any error during adding input
+    e) The underlying mediapipe graph occurs any error during adding input
        packets.
 )doc",
       py::arg("input_packets"));
@@ -208,7 +208,7 @@ After the runner is closed, any calls that send input data to the runner are
 illegal and will receive errors.
 
 Raises:
-  RuntimeError: The underlying medipaipe graph fails to close any input streams
+  RuntimeError: The underlying mediapipe graph fails to close any input streams
     or calculators.
 )doc");
 
@@ -223,7 +223,7 @@ Raises:
 This can be useful for resetting a stateful task graph to process new data.
 
 Raises:
-  RuntimeError: The underlying medipaipe graph fails to reset and restart.
+  RuntimeError: The underlying mediapipe graph fails to reset and restart.
 )doc");
 
   task_runner.def(

--- a/mediapipe/tasks/python/genai/bundler/__init__.py
+++ b/mediapipe/tasks/python/genai/bundler/__init__.py
@@ -14,7 +14,7 @@
 
 """MediaPipe Tasks GenAI Bundler API."""
 
-import mediapipe.tasks.python.genai.bundler.llm_bundler
+import mediapipe.tasks.python.genai.bundler.llm_bundler as llm_bundler
 
 BundleConfig = llm_bundler.BundleConfig
 create_bundle = llm_bundler.create_bundle

--- a/mediapipe/tasks/python/genai/bundler/llm_bundler.py
+++ b/mediapipe/tasks/python/genai/bundler/llm_bundler.py
@@ -18,9 +18,9 @@ import dataclasses
 import enum
 from typing import List, Optional
 
+import sentencepiece
 from mediapipe.tasks.python.metadata.metadata_writers import model_asset_bundle_utils
 from mediapipe.tasks.cc.genai.inference.proto import llm_params_pb2
-import sentencepiece
 
 
 @dataclasses.dataclass(frozen=True)
@@ -30,7 +30,7 @@ class BundleConfig:
   Attributes:
     tflite_model: Path to the multi-signature tflite model with "prefill" and
       "decode" signatures converted using ODML Transformers APIs.
-    tokenizer_model: Path to the tokenizer model. Currently only SentencePience
+    tokenizer_model: Path to the tokenizer model. Currently only SentencePiece
       tokenizer is supported. As such, tokenizer.model proto is expected to be
       passed here.
     start_token: Token that will be used to signify the beginning of a sequence.

--- a/mediapipe/tasks/python/genai/bundler/llm_bundler_test.py
+++ b/mediapipe/tasks/python/genai/bundler/llm_bundler_test.py
@@ -17,9 +17,9 @@ import string
 import zipfile
 
 from absl.testing import absltest
+from sentencepiece import sentencepiece_model_pb2
 
 from mediapipe.tasks.python.genai.bundler import llm_bundler
-from sentencepiece import sentencepiece_model_pb2
 
 
 class LlmBundlerTest(absltest.TestCase):
@@ -127,7 +127,7 @@ class LlmBundlerTest(absltest.TestCase):
         tflite_model=tflite_file_path,
         tokenizer_model=sp_file_path,
         start_token=self.BOS,
-        stop_tokens=self.EOS,
+        stop_tokens=[self.EOS],
         output_filename=output_file,
     )
     with self.assertRaisesRegex(

--- a/mediapipe/tasks/python/genai/converter/__init__.py
+++ b/mediapipe/tasks/python/genai/converter/__init__.py
@@ -14,11 +14,10 @@
 
 """MediaPipe Tasks GenAI Converter API."""
 
-import mediapipe.tasks.python.genai.converter.llm_converter
+import mediapipe.tasks.python.genai.converter.llm_converter as llm_converter
 
 ConversionConfig = llm_converter.ConversionConfig
 convert_checkpoint = llm_converter.convert_checkpoint
 
 # Remove unnecessary modules to avoid duplication in API docs.
-del mediapipe
 del llm_converter

--- a/mediapipe/tasks/python/genai/converter/converter_base.py
+++ b/mediapipe/tasks/python/genai/converter/converter_base.py
@@ -14,9 +14,8 @@
 
 """Defines a couple base classes for the conversion/quantization process."""
 
-from typing import Iterator
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Iterator
 import numpy as np
 
 

--- a/mediapipe/tasks/python/genai/converter/pytorch_converter.py
+++ b/mediapipe/tasks/python/genai/converter/pytorch_converter.py
@@ -14,10 +14,9 @@
 
 """CkptLoader implementation for loading the Pytorch file."""
 
-from typing import Iterator
 import enum
 import os
-from typing import List, Optional
+from typing import List, Optional, Iterator
 
 import numpy as np
 import torch

--- a/mediapipe/tasks/python/metadata/metadata.py
+++ b/mediapipe/tasks/python/metadata/metadata.py
@@ -401,7 +401,7 @@ class MetadataPopulator(object):
             "tflite model is still allowed.".format(f))
 
   def _copy_archived_files(self, src_zip, file_list, dst_zip):
-    """Copy archieved files in file_list from src_zip ro dst_zip."""
+    """Copy archived files in file_list from src_zip ro dst_zip."""
 
     if not _is_zipfile(src_zip):
       raise ValueError("File, '{0}', is not a zipfile.".format(src_zip))
@@ -585,7 +585,7 @@ class MetadataPopulator(object):
       metadata_field.buffer = len(model.buffers) - 1
       model.metadata.append(metadata_field)
 
-    # Packs model back to a flatbuffer binaray file.
+    # Packs model back to a flatbuffer binary file.
     b = flatbuffers.Builder(0)
     b.Finish(model.Pack(b), self.TFLITE_FILE_IDENTIFIER)
     model_buf = b.Output()

--- a/mediapipe/tasks/python/metadata/metadata_writers/face_stylizer.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/face_stylizer.py
@@ -87,7 +87,7 @@ class MetadataWriter:
         inside.
       input_norm_mean: the mean value used in the input tensor normalization for
         face stylizer model [1].
-      input_norm_std: the std value used in the input tensor normalizarion for
+      input_norm_std: the std value used in the input tensor normalization for
         face stylizer model [1].
 
       [1]:

--- a/mediapipe/tasks/python/metadata/metadata_writers/image_classifier.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/image_classifier.py
@@ -47,7 +47,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       model_buffer: A valid flatbuffer loaded from the TFLite model file.
       input_norm_mean: the mean value used in the input tensor normalization
         [1].
-      input_norm_std: the std value used in the input tensor normalizarion [1].
+      input_norm_std: the std value used in the input tensor normalization [1].
       labels: an instance of Labels helper class used in the output
         classification tensor [2].
       score_calibration: A container of the score calibration operation [3] in

--- a/mediapipe/tasks/python/metadata/metadata_writers/image_segmenter.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/image_segmenter.py
@@ -135,7 +135,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       model_buffer: A valid flatbuffer loaded from the TFLite model file.
       input_norm_mean: the mean value used in the input tensor normalization
         [1].
-      input_norm_std: the std value used in the input tensor normalizarion [1].
+      input_norm_std: the std value used in the input tensor normalization [1].
       labels: an instance of Labels helper class used in the output category
         tensor [2].
       activation: activation function for the output layer.

--- a/mediapipe/tasks/python/metadata/metadata_writers/metadata_info.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/metadata_info.py
@@ -918,7 +918,7 @@ class DetectionOutputTensorsMd:
 
   _LOCATION_NAME = "location"
   _LOCATION_DESCRIPTION = "The locations of the detected boxes."
-  _CATRGORY_NAME = "category"
+  _CATEGORY_NAME = "category"
   _CATEGORY_DESCRIPTION = "The categories of the detected boxes."
   _SCORE_NAME = "score"
   _SCORE_DESCRIPTION = "The scores of the detected boxes."
@@ -954,7 +954,7 @@ class DetectionOutputTensorsMd:
         content_range_md=content_range_md,
     )
     category_md = CategoryTensorMd(
-        name=self._CATRGORY_NAME,
+        name=self._CATEGORY_NAME,
         description=self._CATEGORY_DESCRIPTION,
         label_files=label_files,
         content_range_md=content_range_md,

--- a/mediapipe/tasks/python/metadata/metadata_writers/metadata_writer.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/metadata_writer.py
@@ -42,7 +42,7 @@ _OUTPUT_SEGMENTATION_MASKS_DESCRIPTION = (
 # Detection tensor result to be grouped together.
 _DETECTION_GROUP_NAME = 'detection_result'
 # File name to export score calibration parameters.
-_SCORE_CALIBATION_FILENAME = 'score_calibration.txt'
+_SCORE_CALIBRATION_FILENAME = 'score_calibration.txt'
 
 
 @dataclasses.dataclass
@@ -409,7 +409,7 @@ class MetadataWriter(object):
   with open(model_path, 'rb') as f:
     writer = MetadataWriter.create(f.read())
     model_content, metadata_json_content = writer
-        .add_genernal_info('model_name', 'model description')
+        .add_general_info('model_name', 'model description')
         .add_image_input()
         .add_feature_input()
         .add_classification_output(Labels().add(['A', 'B']))
@@ -439,7 +439,7 @@ class MetadataWriter(object):
       self,
       model_name: str,
       model_description: Optional[str] = None) -> 'MetadataWriter':
-    """Adds a general info metadata for the general metadata informantion."""
+    """Adds a general info metadata for the general metadata information."""
     # Will overwrite the previous `self._general_md` if exists.
     self._general_md = metadata_info.GeneralMd(
         name=model_name, description=model_description)
@@ -535,7 +535,7 @@ class MetadataWriter(object):
 
     Args:
       tokenizer: information of the tokenizer used to process the input string,
-        if any. Supported tokenziers are: `BertTokenizer` [1] and
+        if any. Supported tokenizers are: `BertTokenizer` [1] and
         `SentencePieceTokenizer` [2].
       ids_name: name of the ids tensor, which represents the tokenized ids of
         the input text.
@@ -802,7 +802,7 @@ class MetadataWriter(object):
         score_transformation_type=score_calibration.transformation_type,
         default_score=score_calibration.default_score,
         file_path=self._export_calibration_file(
-            _SCORE_CALIBATION_FILENAME, score_calibration.parameters
+            _SCORE_CALIBRATION_FILENAME, score_calibration.parameters
         ),
     )
 

--- a/mediapipe/tasks/python/metadata/metadata_writers/object_detector.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/object_detector.py
@@ -92,7 +92,7 @@ class TensorsDecodingOptions:
   h_scale: float
   # Whether to apply exponential on box size.
   apply_exponential_on_box_size: bool
-  # Whether to apply sigmod function on the score.
+  # Whether to apply sigmoid function on the score.
   sigmoid_score: bool
 
 
@@ -239,7 +239,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       model_buffer: A valid flatbuffer loaded from the TFLite model file.
       input_norm_mean: the mean value used in the input tensor normalization
         [2].
-      input_norm_std: the std value used in the input tensor normalizarion [2].
+      input_norm_std: the std value used in the input tensor normalization [2].
       labels: an instance of Labels helper class used in the output
         classification tensor [3].
       score_calibration: A container of the score calibration operation [4] in
@@ -294,7 +294,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       model_buffer: A valid flatbuffer loaded from the TFLite model file.
       input_norm_mean: the mean value used in the input tensor normalization
         [2].
-      input_norm_std: the std value used in the input tensor normalizarion [2].
+      input_norm_std: the std value used in the input tensor normalization [2].
       labels: an instance of Labels helper class used in the output
         classification tensor [3].
       ssd_anchors_options: the ssd anchors options associated to the object

--- a/mediapipe/tasks/python/metadata/metadata_writers/text_classifier.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/text_classifier.py
@@ -19,7 +19,7 @@ from typing import Union
 from mediapipe.tasks.python.metadata.metadata_writers import metadata_writer
 
 _MODEL_NAME = "TextClassifier"
-_MODEL_DESCRIPTION = ("Classify the input text into a set of known categories.")
+_MODEL_DESCRIPTION = "Classify the input text into a set of known categories."
 
 # The input tensor names of models created by Model Maker.
 _DEFAULT_ID_NAME = "serving_default_input_word_ids:0"
@@ -35,7 +35,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       cls, model_buffer: bytearray,
       regex_tokenizer: metadata_writer.RegexTokenizer,
       labels: metadata_writer.Labels) -> "MetadataWriter":
-    """Creates MetadataWriter for TFLite model with regex tokentizer.
+    """Creates MetadataWriter for TFLite model with regex tokenizer.
 
     The parameters required in this method are mandatory when using MediaPipe
     Tasks.
@@ -90,7 +90,7 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
     Args:
       model_buffer: valid buffer of the model file.
       tokenizer: information of the tokenizer used to process the input string,
-        if any. Supported tokenziers are: `BertTokenizer` [1] and
+        if any. Supported tokenizers are: `BertTokenizer` [1] and
         `SentencePieceTokenizer` [2]. If the tokenizer is `RegexTokenizer` [3],
         refer to `create_for_regex_model`.
       labels: an instance of Labels helper class used in the output

--- a/mediapipe/tasks/python/text/__init__.py
+++ b/mediapipe/tasks/python/text/__init__.py
@@ -14,9 +14,9 @@
 
 """MediaPipe Tasks Text API."""
 
-import mediapipe.tasks.python.text.language_detector
-import mediapipe.tasks.python.text.text_classifier
-import mediapipe.tasks.python.text.text_embedder
+import mediapipe.tasks.python.text.language_detector as language_detector
+import mediapipe.tasks.python.text.text_classifier as text_classifier
+import mediapipe.tasks.python.text.text_embedder as text_embedder
 
 LanguageDetector = language_detector.LanguageDetector
 LanguageDetectorOptions = language_detector.LanguageDetectorOptions
@@ -29,7 +29,6 @@ TextEmbedderOptions = text_embedder.TextEmbedderOptions
 TextEmbedderResult = text_embedder.TextEmbedderResult
 
 # Remove unnecessary modules to avoid duplication in API docs.
-del mediapipe
 del language_detector
 del text_classifier
 del text_embedder

--- a/mediapipe/tasks/python/vision/__init__.py
+++ b/mediapipe/tasks/python/vision/__init__.py
@@ -14,20 +14,20 @@
 
 """MediaPipe Tasks Vision API."""
 
-import mediapipe.tasks.python.vision.core
-import mediapipe.tasks.python.vision.face_aligner
-import mediapipe.tasks.python.vision.face_detector
-import mediapipe.tasks.python.vision.face_landmarker
-import mediapipe.tasks.python.vision.face_stylizer
-import mediapipe.tasks.python.vision.gesture_recognizer
-import mediapipe.tasks.python.vision.hand_landmarker
-import mediapipe.tasks.python.vision.holistic_landmarker
-import mediapipe.tasks.python.vision.image_classifier
-import mediapipe.tasks.python.vision.image_embedder
-import mediapipe.tasks.python.vision.image_segmenter
-import mediapipe.tasks.python.vision.interactive_segmenter
-import mediapipe.tasks.python.vision.object_detector
-import mediapipe.tasks.python.vision.pose_landmarker
+import mediapipe.tasks.python.vision.core as core
+import mediapipe.tasks.python.vision.face_aligner as face_aligner
+import mediapipe.tasks.python.vision.face_detector as face_detector
+import mediapipe.tasks.python.vision.face_landmarker as face_landmarker
+import mediapipe.tasks.python.vision.face_stylizer as face_stylizer
+import mediapipe.tasks.python.vision.gesture_recognizer as gesture_recognizer
+import mediapipe.tasks.python.vision.hand_landmarker as hand_landmarker
+import mediapipe.tasks.python.vision.holistic_landmarker as holistic_landmarker
+import mediapipe.tasks.python.vision.image_classifier as image_classifier
+import mediapipe.tasks.python.vision.image_embedder as image_embedder
+import mediapipe.tasks.python.vision.image_segmenter as image_segmenter
+import mediapipe.tasks.python.vision.interactive_segmenter as interactive_segmenter
+import mediapipe.tasks.python.vision.object_detector as object_detector
+import mediapipe.tasks.python.vision.pose_landmarker as pose_landmarker
 
 FaceAligner = face_aligner.FaceAligner
 FaceAlignerOptions = face_aligner.FaceAlignerOptions
@@ -87,4 +87,3 @@ del image_segmenter
 del interactive_segmenter
 del object_detector
 del pose_landmarker
-del mediapipe

--- a/mediapipe/tasks/python/vision/core/base_vision_task_api.py
+++ b/mediapipe/tasks/python/vision/core/base_vision_task_api.py
@@ -140,7 +140,7 @@ class BaseVisionTaskApi(object):
 
   def convert_to_normalized_rect(
       self,
-      options: _ImageProcessingOptions,
+      options: Optional[_ImageProcessingOptions],
       image: image_module.Image,
       roi_allowed: bool = True,
   ) -> _NormalizedRect:

--- a/mediapipe/tasks/python/vision/gesture_recognizer.py
+++ b/mediapipe/tasks/python/vision/gesture_recognizer.py
@@ -213,7 +213,7 @@ class GestureRecognizerOptions:
     """Generates an GestureRecognizerOptions protobuf object."""
     base_options_proto = self.base_options.to_pb2()
     base_options_proto.use_stream_mode = (
-        False if self.running_mode == _RunningMode.IMAGE else True
+        self.running_mode != _RunningMode.IMAGE
     )
 
     # Initialize gesture recognizer options from base options.

--- a/mediapipe/tasks/python/vision/image_segmenter.py
+++ b/mediapipe/tasks/python/vision/image_segmenter.py
@@ -124,7 +124,7 @@ class ImageSegmenter(base_vision_task_api.BaseVisionTaskApi):
     (kTfLiteUInt8/kTfLiteFloat32)
     - image input of size `[batch x height x width x channels]`.
     - batch inference is not supported (`batch` is required to be 1).
-    - RGB and greyscale inputs are supported (`channels` is required to be
+    - RGB and grayscale inputs are supported (`channels` is required to be
       1 or 3).
     - if type is kTfLiteFloat32, NormalizationOptions are required to be
       attached to the metadata for input normalization.
@@ -391,7 +391,7 @@ class ImageSegmenter(base_vision_task_api.BaseVisionTaskApi):
     input images if needed. In other words, it's not guaranteed to have output
     per input image.
 
-    The `result_callback` prvoides:
+    The `result_callback` provides:
       - A segmentation result object that contains a list of segmentation masks
         as images.
       - The input image that the image segmenter runs on.

--- a/mediapipe/tasks/python/vision/interactive_segmenter.py
+++ b/mediapipe/tasks/python/vision/interactive_segmenter.py
@@ -146,7 +146,7 @@ class InteractiveSegmenter(base_vision_task_api.BaseVisionTaskApi):
     (kTfLiteUInt8/kTfLiteFloat32)
     - image input of size `[batch x height x width x channels]`.
     - batch inference is not supported (`batch` is required to be 1).
-    - RGB and greyscale inputs are supported (`channels` is required to be
+    - RGB and grayscale inputs are supported (`channels` is required to be
       1 or 3).
     - if type is kTfLiteFloat32, NormalizationOptions are required to be
       attached to the metadata for input normalization.

--- a/mediapipe/tasks/python/vision/object_detector.py
+++ b/mediapipe/tasks/python/vision/object_detector.py
@@ -359,7 +359,7 @@ class ObjectDetector(base_vision_task_api.BaseVisionTaskApi):
     images if needed. In other words, it's not guaranteed to have output per
     input image.
 
-    The `result_callback` prvoides:
+    The `result_callback` provides:
       - A detection result object that contains a list of detections, each
         detection has a bounding box that is expressed in the unrotated input
         frame of reference coordinates system, i.e. in `[0,image_width) x [0,


### PR DESCRIPTION
Fixed Multiple Typos and Changed some Python Import Statements to get correct Type Definitions in Editor.

> Also, there seems to be no CODE_OF_CONDUCT.md file as linked in Contributing Guidelines.