### PR TITLE
Lazily import matplotlib

### DIFF
--- a/mediapipe/python/solutions/drawing_utils.py
+++ b/mediapipe/python/solutions/drawing_utils.py
@@ -18,7 +18,6 @@ import math
 from typing import List, Mapping, Optional, Tuple, Union
 
 import cv2
-import matplotlib.pyplot as plt
 import numpy as np
 
 from mediapipe.framework.formats import detection_pb2
@@ -281,6 +280,11 @@ def plot_landmarks(landmark_list: landmark_pb2.NormalizedLandmarkList,
   """
   if not landmark_list:
     return
+
+  # Matplotlib is used only here: import it lazily to improve the import
+  # time of mediapipe for users not calling this function
+  import matplotlib.pyplot as plt
+
   plt.figure(figsize=(10, 10))
   ax = plt.axes(projection='3d')
   ax.view_init(elev=elevation, azim=azimuth)


### PR DESCRIPTION
Matplotlib is a large and slow to import dependecy of mediapipe but it is used in only one function. Currently matplotlib is imported when caling `import mediapipe`.

This MR moves the matplotlib import inside the only function that depends on matplotlib. For people who don't call this function:

- the import time will be faster
- they could uninstall matplotlib and still use mediapipe (related to #3661)

(Ideally, matplotlib would become an optional dependecy.)