### PR TITLE
Removing invalid commas from several module files

### DIFF
--- a/mediapipe/modules/holistic_landmark/hand_landmarks_from_pose_cpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/hand_landmarks_from_pose_cpu.pbtxt
@@ -53,7 +53,7 @@ node {
 
 # Predicts hand re-crop rectangle on the current frame.
 node {
-  calculator: "HandRecropByRoiCpu",
+  calculator: "HandRecropByRoiCpu"
   input_stream: "IMAGE:input_video"
   input_stream: "ROI:hand_roi_from_pose"
   output_stream: "HAND_ROI_FROM_RECROP:hand_roi_from_recrop"

--- a/mediapipe/modules/holistic_landmark/hand_landmarks_from_pose_gpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/hand_landmarks_from_pose_gpu.pbtxt
@@ -53,7 +53,7 @@ node {
 
 # Predicts hand re-crop rectangle on the current frame.
 node {
-  calculator: "HandRecropByRoiGpu",
+  calculator: "HandRecropByRoiGpu"
   input_stream: "IMAGE:input_video"
   input_stream: "ROI:hand_roi_from_pose"
   output_stream: "HAND_ROI_FROM_RECROP:hand_roi_from_recrop"

--- a/mediapipe/modules/holistic_landmark/hand_recrop_by_roi_cpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/hand_recrop_by_roi_cpu.pbtxt
@@ -30,7 +30,7 @@ node {
         max: 1.0
       }
       # For OpenGL origin should be at the top left corner.
-      gpu_origin: TOP_LEFT,
+      gpu_origin: TOP_LEFT
     }
   }
 }

--- a/mediapipe/modules/holistic_landmark/hand_recrop_by_roi_gpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/hand_recrop_by_roi_gpu.pbtxt
@@ -30,7 +30,7 @@ node {
         max: 1.0
       }
       # For OpenGL origin should be at the top left corner.
-      gpu_origin: TOP_LEFT,
+      gpu_origin: TOP_LEFT
     }
   }
 }


### PR DESCRIPTION
The `HandRecropByRoi` and the `HandLandmarksFromPose` module files contain invalid comma characters, which results in a parse error when loaded into the [MediaPipe Visualizer](https://viz.mediapipe.dev/). These invalid characters have been removed, allowing the Visualizer to load the module files properly.