### PR TITLE
Fix: Import fix in pose.py for applying kernel size properly

### DIFF
--- a/mediapipe/python/solutions/pose.py
+++ b/mediapipe/python/solutions/pose.py
@@ -39,6 +39,7 @@ from mediapipe.calculators.util import local_file_contents_calculator_pb2
 from mediapipe.calculators.util import logic_calculator_pb2
 from mediapipe.calculators.util import non_max_suppression_calculator_pb2
 from mediapipe.calculators.util import rect_transformation_calculator_pb2
+from mediapipe.calculators.util import refine_landmarks_from_heatmap_calculator_pb2
 from mediapipe.calculators.util import thresholding_calculator_pb2
 from mediapipe.calculators.util import visibility_smoothing_calculator_pb2
 from mediapipe.framework.tool import switch_container_pb2


### PR DESCRIPTION
The kernel size of the `RefineLandmarksFromHeatmapCalculator` is overridden for Pose landmarks to 7 [here](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/modules/pose_landmark/tensors_to_pose_landmarks_and_segmentation.pbtxt#L173).

This is applied indeed to the Example Application but not to the Python solution, where the [default value](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/calculators/util/refine_landmarks_from_heatmap_calculator.proto#L25) (9) is used.

The issue is that the related proto file import is missing from pose.py.