### PR TITLE
Fix #5876: Windows build fails with OpenCV 3.4.10

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -613,7 +613,7 @@ next section.
 8.  Install OpenCV.
 
     Download the Windows executable from https://opencv.org/releases/ and
-    install. We currently use OpenCV 3.4.10. Remember to edit the [`WORKSPACE`]
+    install. We currently use OpenCV 3.4.12. Remember to edit the [`WORKSPACE`]
     file if OpenCV is not installed at `C:\opencv`.
 
     ```

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])  # BSD license
 
 exports_files(["LICENSE"])
 
-OPENCV_VERSION = "3410"  # 3.4.10
+OPENCV_VERSION = "3412"  # 3.4.12
 
 config_setting(
     name = "opt_build",
@@ -17,7 +17,7 @@ config_setting(
     values = {"compilation_mode": "dbg"},
 )
 
-# The following build rule assumes that the executable "opencv-3.4.10-vc14_vc15.exe"
+# The following build rule assumes that the executable "opencv-3.4.12-vc14_vc15.exe"
 # is downloaded and the files are extracted to local.
 # If you install OpenCV separately, please modify the build rule accordingly.
 cc_library(


### PR DESCRIPTION
Update the required OpenCV version to 3.4.12.
The project uses `CAP_PROP_ORIENTATION_AUTO` contant that was introduced in OpenCV 3.4.12, thus is not accesible in OpenCV 3.4.10
https://github.com/opencv/opencv/commit/f0271e54d90b3af62301f531f5f00995b00d7cd6

Using of OpenCV 3.4.10 leads to a build error
```
mediapipe/calculators/video/opencv_video_decoder_calculator.cc(116): error C2039: 'CAP_PROP_ORIENTATION_AUTO': is not a member of 'cv'
external/windows_opencv/include\opencv2/videoio.hpp(71): note: see declaration of 'cv'
mediapipe/calculators/video/opencv_video_decoder_calculator.cc(116): error C2065: 'CAP_PROP_ORIENTATION_AUTO': undeclared identifier
Target //mediapipe/examples/desktop/hand_tracking:hand_tracking_cpu failed to build
```