### PR TITLE
Fixed python hand palm connection

### DIFF
--- a/mediapipe/tasks/python/vision/hand_landmarker.py
+++ b/mediapipe/tasks/python/vision/hand_landmarker.py
@@ -94,7 +94,7 @@ class HandLandmarksConnections:
 
   HAND_PALM_CONNECTIONS: List[Connection] = [
       Connection(0, 1),
-      Connection(1, 5),
+      Connection(0, 5),
       Connection(9, 13),
       Connection(13, 17),
       Connection(5, 9),


### PR DESCRIPTION
I noticed the palm landmark connections in the documentation did not correlate with the Python implementation. It's implemented as (1,5) in python but the docs show it should be (0,5). I also confirmed with the `cc`, `ios`, `java` and `web` implementations that confirm that it should be (0,5).