### PR TITLE
Enable multi-class NMS for object detector

### DIFF
--- a/Dockerfile.manylinux_2_28_x86_64
+++ b/Dockerfile.manylinux_2_28_x86_64
@@ -77,6 +77,7 @@ RUN cd /tmp/bazel_build/opencv && git checkout 4.10.0 && cd release && cmake .. 
 RUN cd /tmp/bazel_build/opencv/release && make -j 16 && make install
 
 COPY . /mediapipe/
+COPY third_party/mediapipe_python_build.diff /mediapipe/
 WORKDIR /mediapipe
 
 # Set version number

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -321,6 +321,7 @@ python_init_rules()
 
 load("@org_tensorflow//third_party/xla/third_party/py:python_init_repositories.bzl", "python_init_repositories")
 
+# Set `default_python_version` to "3.12" when building Dockerfile.manylinux_2_28_x86_64
 python_init_repositories(
     default_python_version = "system",
     local_wheel_dist_folder = "dist",

--- a/mediapipe/gpu/webgpu/webgpu_shader_calculator.proto
+++ b/mediapipe/gpu/webgpu/webgpu_shader_calculator.proto
@@ -4,7 +4,6 @@ package mediapipe;
 
 import "mediapipe/framework/calculator.proto";
 
-option cc_api_version = 2;
 
 message WebGpuShaderCalculatorOptions {
   extend CalculatorOptions {

--- a/mediapipe/tasks/ios/vision/object_detector/sources/MPPObjectDetectorOptions.h
+++ b/mediapipe/tasks/ios/vision/object_detector/sources/MPPObjectDetectorOptions.h
@@ -103,6 +103,12 @@ NS_SWIFT_NAME(ObjectDetectorOptions)
 @property(nonatomic) float scoreThreshold;
 
 /**
+ * Whether to use multiclass NMS. When true, each category performs non-maximum-suppression 
+ * separately. Defaults to false.
+ */
+ @property(nonatomic) bool multiclassNms;
+
+/**
  * The allowlist of category names. If non-empty, detection results whose category name is not in
  * this set will be filtered out. Duplicate or unknown category names are ignored. Mutually
  * exclusive with categoryDenylist.

--- a/mediapipe/tasks/ios/vision/object_detector/sources/MPPObjectDetectorOptions.m
+++ b/mediapipe/tasks/ios/vision/object_detector/sources/MPPObjectDetectorOptions.m
@@ -21,6 +21,7 @@
   if (self) {
     _maxResults = -1;
     _scoreThreshold = 0;
+    _multiclassNms = NO;
   }
   return self;
 }
@@ -34,6 +35,7 @@
   objectDetectorOptions.categoryDenylist = self.categoryDenylist;
   objectDetectorOptions.categoryAllowlist = self.categoryAllowlist;
   objectDetectorOptions.displayNamesLocale = self.displayNamesLocale;
+  objectDetectorOptions.multiclassNms = self.multiclassNms;
   objectDetectorOptions.objectDetectorLiveStreamDelegate = self.objectDetectorLiveStreamDelegate;
 
   return objectDetectorOptions;

--- a/mediapipe/tasks/ios/vision/object_detector/utils/sources/MPPObjectDetectorOptions+Helpers.mm
+++ b/mediapipe/tasks/ios/vision/object_detector/utils/sources/MPPObjectDetectorOptions+Helpers.mm
@@ -41,6 +41,7 @@ using ObjectDetectorOptionsProto =
 
   graphOptions->set_max_results((int)self.maxResults);
   graphOptions->set_score_threshold(self.scoreThreshold);
+  graphOptions->set_multiclass_nms(self.multiclassNms);
 
   for (NSString *category in self.categoryAllowlist) {
     graphOptions->add_category_allowlist(category.cppString);

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/objectdetector/ObjectDetector.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/objectdetector/ObjectDetector.java
@@ -439,6 +439,12 @@ public final class ObjectDetector extends BaseVisionTaskApi {
       public abstract Builder setCategoryDenylist(List<String> value);
 
       /**
+       * Sets whether to use multiclass NMS. When true, each category processes non-maximum-suppression 
+       * separately. Defaults to false.
+       */
+      public abstract Builder setMulticlassNms(Boolean value);
+
+      /**
        * Sets the {@link ResultListener} to receive the detection results asynchronously when the
        * object detector is in the live stream mode.
        */
@@ -494,6 +500,8 @@ public final class ObjectDetector extends BaseVisionTaskApi {
 
     abstract Optional<ErrorListener> errorListener();
 
+    abstract Optional<Boolean> multiclassNms();
+
     public static Builder builder() {
       return new AutoValue_ObjectDetector_ObjectDetectorOptions.Builder()
           .setRunningMode(RunningMode.IMAGE)
@@ -520,6 +528,7 @@ public final class ObjectDetector extends BaseVisionTaskApi {
       if (!categoryDenylist().isEmpty()) {
         taskOptionsBuilder.addAllCategoryDenylist(categoryDenylist());
       }
+      multiclassNms().ifPresent(taskOptionsBuilder::setMulticlassNms);
       return CalculatorOptions.newBuilder()
           .setExtension(
               ObjectDetectorOptionsProto.ObjectDetectorOptions.ext, taskOptionsBuilder.build())

--- a/mediapipe/tasks/python/vision/object_detector.py
+++ b/mediapipe/tasks/python/vision/object_detector.py
@@ -66,6 +66,8 @@ class ObjectDetectorOptions:
       return.
     score_threshold: Overrides the ones provided in the model metadata. Results
       below this value are rejected.
+    multiclass_nms: Whether to use multiclass NMS. That is, each category processes
+      non-maximum-suppression separately.
     category_allowlist: Allowlist of category names. If non-empty, detection
       results whose category name is not in this set will be filtered out.
       Duplicate or unknown category names are ignored. Mutually exclusive with
@@ -84,6 +86,7 @@ class ObjectDetectorOptions:
   display_names_locale: Optional[str] = None
   max_results: Optional[int] = None
   score_threshold: Optional[float] = None
+  multiclass_nms: Optional[bool] = None
   category_allowlist: Optional[List[str]] = None
   category_denylist: Optional[List[str]] = None
   result_callback: Optional[
@@ -102,6 +105,7 @@ class ObjectDetectorOptions:
         display_names_locale=self.display_names_locale,
         max_results=self.max_results,
         score_threshold=self.score_threshold,
+        multiclass_nms=self.multiclass_nms,
         category_allowlist=self.category_allowlist,
         category_denylist=self.category_denylist,
     )

--- a/mediapipe/tasks/web/build_web_task.sh
+++ b/mediapipe/tasks/web/build_web_task.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Usage:  
+# From mediapipe root folder:
+# $ bash ./mediapipe/tasks/web/build_web_task.sh <TASK_NAME>
+# TASK_NAME should be one of: common, vision, text, audio, genai
+
+set -e
+
+# Validate and set TASK_NAME
+TASK_NAME=$1
+
+if [[ -z "$TASK_NAME" ]]; then
+    echo "Error: TASK_NAME is required."
+    echo "Usage: $0 TASK_NAME"
+    echo "TASK_NAME should be one of: common, vision, text, audio, genai"
+    exit 1
+fi
+
+# Step 1: Build the Docker image
+docker build -t mediapipe .
+
+# Step 2: Define the build script to run inside the container
+script="bazel build //mediapipe/tasks/web/$TASK_NAME:all; \
+     npm install -g @microsoft/api-extractor; \
+     cp mediapipe/tasks/web/$TASK_NAME/api-extractor.json bazel-out/k8-fastbuild/bin/mediapipe/tasks/web/$TASK_NAME/api-extractor.json; \
+     cp tsconfig.json bazel-out/k8-fastbuild/bin/mediapipe/tasks/web/$TASK_NAME/tsconfig.json; \
+     cd bazel-out/k8-fastbuild/bin/mediapipe/tasks/web/$TASK_NAME; npx api-extractor run; \
+     cp -rf ${TASK_NAME}_pkg /mediapipe/${TASK_NAME}_pkg; \
+     echo Done. "
+
+# Step 3: Run the container with your local project mounted
+docker run -v "$(pwd)":/mediapipe --rm -it mediapipe bash -c "$script"

--- a/mediapipe/tasks/web/vision/object_detector/object_detector.ts
+++ b/mediapipe/tasks/web/vision/object_detector/object_detector.ts
@@ -167,6 +167,13 @@ export class ObjectDetector extends VisionTaskRunner {
       this.options.clearScoreThreshold();
     }
 
+    if (options.multiclassNms !== undefined) {
+      this.options.setMulticlassNms(options.multiclassNms);
+    } else if ('multiclassNms' in options) {
+      // Check for undefined
+      this.options.clearMulticlassNms();
+    }
+
     if (options.categoryAllowlist !== undefined) {
       this.options.setCategoryAllowlistList(options.categoryAllowlist);
     } else if ('categoryAllowlist' in options) {

--- a/mediapipe/tasks/web/vision/object_detector/object_detector_options.d.ts
+++ b/mediapipe/tasks/web/vision/object_detector/object_detector_options.d.ts
@@ -19,4 +19,10 @@ import {VisionTaskOptions} from '../../../../tasks/web/vision/core/vision_task_o
 
 /** Options to configure the MediaPipe Object Detector Task */
 export declare interface ObjectDetectorOptions extends VisionTaskOptions,
-                                                       ClassifierOptions {}
+                                                     ClassifierOptions {
+  /**
+   * Whether to use multiclass non-maximum suppression. That is, each category
+   * processes non-maximum-suppression separately.
+   */
+  multiclassNms?: boolean;
+}


### PR DESCRIPTION
This pull request enabled multi-class NMS for object detectors in vision package, for all APIs including iOS, Java, Python and web.

Also included in this pull request:
- Fixed Dockerfile.manylinux_2_28_x86_64 file for building Python wheel.
- Added script to build for web with modified from https://github.com/whatisor/mediapipe/blob/master/build_tasks_vision.sh.
