### PR TITLE
Fix docstring typo and add matplotlib plot cleanup in drawing_utils

### DIFF
--- a/mediapipe/python/solutions/drawing_utils.py
+++ b/mediapipe/python/solutions/drawing_utils.py
@@ -70,7 +70,7 @@ def draw_detection(
     detection: detection_pb2.Detection,
     keypoint_drawing_spec: DrawingSpec = DrawingSpec(color=RED_COLOR),
     bbox_drawing_spec: DrawingSpec = DrawingSpec()):
-  """Draws the detction bounding box and keypoints on the image.
+  """Draws the detection bounding box and keypoints on the image.
 
   Args:
     image: A three channel BGR image represented as numpy ndarray.

--- a/mediapipe/python/solutions/drawing_utils.py
+++ b/mediapipe/python/solutions/drawing_utils.py
@@ -318,3 +318,4 @@ def plot_landmarks(landmark_list: landmark_pb2.NormalizedLandmarkList,
             color=_normalize_color(connection_drawing_spec.color[::-1]),
             linewidth=connection_drawing_spec.thickness)
   plt.show()
+  plt.close()


### PR DESCRIPTION
Still learning the ropes of the repo. Two small fixes to `drawing_utils.py`:

1. **Fixed typo**: "detction" → "detection" in docstring
2. **Added `plt.close()`**: Prevents memory leaks from unclosed matplotlib plots

Both changes improve code quality without affecting functionality.