### PR TITLE
Fix  'NameError: name 'audio_classifier' is not defined'

### DIFF
--- a/mediapipe/tasks/python/audio/__init__.py
+++ b/mediapipe/tasks/python/audio/__init__.py
@@ -14,9 +14,9 @@
 
 """MediaPipe Tasks Audio API."""
 
-import mediapipe.tasks.python.audio.core
-import mediapipe.tasks.python.audio.audio_classifier
-import mediapipe.tasks.python.audio.audio_embedder
+from mediapipe.tasks.python.audio import audio_classifier
+from mediapipe.tasks.python.audio import audio_embedder
+from mediapipe.tasks.python.audio import core
 
 AudioClassifier = audio_classifier.AudioClassifier
 AudioClassifierOptions = audio_classifier.AudioClassifierOptions


### PR DESCRIPTION
This will fix the "NameError: name 'audio_classifier' is not defined" currently experienced by lots of users.