### PR TITLE
fix: don't try to convert RGBA bitmap from RGB to RGBA

### DIFF
--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/imagesegmenter/ImageSegmenter.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/imagesegmenter/ImageSegmenter.java
@@ -212,7 +212,7 @@ public final class ImageSegmenter extends BaseVisionTaskApi {
           @Override
           public MPImage convertToTaskInput(List<Packet> packets) {
             return new BitmapImageBuilder(
-                    AndroidPacketGetter.getBitmapFromRgb(packets.get(imageOutStreamIndex)))
+                    AndroidPacketGetter.getBitmapFromRgba(packets.get(imageOutStreamIndex)))
                 .build();
           }
         });


### PR DESCRIPTION
The input image needs to be RGBA, as specified in comments below. However, the code interpreted the image as RGB, adding a second alpha channel to the "input" bitmap in the result callback. The pixel data was converted from RGBARGBARGBA to
RGB**A**ARG**A**BAR**A**GBA**A** (new alpha channel in bold)