### PR TITLE
docs: fix typos, duplicates, and outdated links (README, install, iOS, calculators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ iOS), web, desktop, edge devices, and IoT, effortlessly.
 
 ## Get started
 
-You can get started with MediaPipe Solutions by by checking out any of the
+You can get started with MediaPipe Solutions by checking out any of the
 developer guides for
 [vision](https://developers.google.com/mediapipe/solutions/vision/object_detector),
 [text](https://developers.google.com/mediapipe/solutions/text/text_classifier),
@@ -88,12 +88,11 @@ low-level component used to build efficient on-device machine learning
 pipelines, similar to the premade MediaPipe Solutions.
 
 Before using MediaPipe Framework, familiarize yourself with the following key
-[Framework
-concepts](https://developers.google.com/mediapipe/framework/framework_concepts/overview.md):
+[Framework concepts](https://developers.google.com/mediapipe/framework/framework_concepts/overview):
 
-*   [Packets](https://developers.google.com/mediapipe/framework/framework_concepts/packets.md)
-*   [Graphs](https://developers.google.com/mediapipe/framework/framework_concepts/graphs.md)
-*   [Calculators](https://developers.google.com/mediapipe/framework/framework_concepts/calculators.md)
+*   [Packets](https://developers.google.com/mediapipe/framework/framework_concepts/packets)
+*   [Graphs](https://developers.google.com/mediapipe/framework/framework_concepts/graphs)
+*   [Calculators](https://developers.google.com/mediapipe/framework/framework_concepts/calculators)
 
 ## Community
 
@@ -110,8 +109,8 @@ concepts](https://developers.google.com/mediapipe/framework/framework_concepts/o
 We welcome contributions. Please follow these
 [guidelines](https://github.com/google/mediapipe/blob/master/CONTRIBUTING.md).
 
-We use GitHub issues for tracking requests and bugs. Please post questions to
-the MediaPipe Stack Overflow with a `mediapipe` tag.
+We use GitHub issues for tracking requests and bugs. Please post questions on
+Stack Overflow with the [`mediapipe` tag](https://stackoverflow.com/questions/tagged/mediapipe).
 
 ## Resources
 

--- a/docs/framework_concepts/calculators.md
+++ b/docs/framework_concepts/calculators.md
@@ -31,7 +31,7 @@ packets and produces zero or more output streams and/or side packets.
 A calculator is created by defining a new sub-class of the
 [`CalculatorBase`](https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe/framework/calculator_base.cc)
 class, implementing a number of methods, and registering the new sub-class with
-Mediapipe. At a minimum, a new calculator must implement the below four methods
+MediaPipe. At a minimum, a new calculator must implement the below four methods
 
 *   `GetContract()`
     *   Calculator authors can specify the expected types of inputs and outputs

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -26,7 +26,7 @@ future.
 Note: If you plan to use TensorFlow calculators and example apps, there is a
 known issue with gcc and g++ version 6.3 and 7.3. Please use other versions.
 
-Note: To make Mediapipe work with TensorFlow, please set Python 3.7 as the
+Note: To make MediaPipe work with TensorFlow, please set Python 3.7 as the
 default Python version and install the Python "six" library by running `pip3
 install --user six`.
 
@@ -35,7 +35,7 @@ install --user six`.
 1.  Install Bazelisk.
 
     Follow the official
-    [Bazel documentation](https://docs.bazel.build/versions/master/install-bazelisk.html)
+    [Bazel documentation](https://docs.bazel.build/versions/main/install-bazelisk.html)
     to install Bazelisk.
 
 2.  Checkout MediaPipe repository.
@@ -60,7 +60,6 @@ install --user six`.
     Debian 11 (bullseye) | 4.5
     Ubuntu 16.04 LTS     | 2.4
     Ubuntu 18.04 LTS     | 3.2
-    Ubuntu 20.04 LTS     | 4.2
     Ubuntu 20.04 LTS     | 4.2
     Ubuntu 21.04         | 4.5
 

--- a/docs/getting_started/ios.md
+++ b/docs/getting_started/ios.md
@@ -23,7 +23,7 @@ as the primary developer documentation site for MediaPipe as of April 3, 2023.*
 
 Please follow instructions below to build iOS example apps in the supported
 MediaPipe [solutions](../solutions/solutions.md). To learn more about these
-example apps, start from, start from
+example apps, start from
 [Hello World! on iOS](./hello_world_ios.md).
 
 ## Building iOS example apps
@@ -39,8 +39,7 @@ example apps, start from, start from
     xcode-select --install
     ```
 
-3.  Install [Bazelisk](https://github.com/bazelbuild/bazelisk)
-.
+3.  Install [Bazelisk](https://github.com/bazelbuild/bazelisk).
 
     We recommend using [Homebrew](https://brew.sh/) to get the latest versions.
 


### PR DESCRIPTION
This PR makes small, non-functional documentation improvements:

- README: remove duplicated word “by by”; fix Framework Concepts links (remove `.md` extensions); add Stack Overflow link with `mediapipe` tag
- docs/install: remove duplicate Ubuntu 20.04 row; correct MediaPipe casing; update Bazelisk install link
- docs/ios: fix repeated phrase and stray punctuation
- docs/calculators: correct MediaPipe casing

These are minor edits intended to improve clarity and reduce friction for newcomers. No code or build files are affected.