### PR TITLE
Fix for media_sequence build on linux

### DIFF
--- a/mediapipe/calculators/tensorflow/BUILD
+++ b/mediapipe/calculators/tensorflow/BUILD
@@ -94,6 +94,15 @@ proto_library(
     srcs = ["tensor_to_vector_string_calculator_options.proto"],
     deps = ["//mediapipe/framework:calculator_proto"],
 )
+# Added the missing proto target so Bazel can generate the C++ bindings for PackMediaSequenceCalculator.
+mediapipe_proto_library(
+    name = "pack_media_sequence_calculator_proto",
+    srcs = ["pack_media_sequence_calculator.proto"],
+    deps = [
+        "//mediapipe/framework:calculator_proto",
+        "@org_tensorflow//tensorflow/core:protos_all",
+    ],
+)
 
 mediapipe_proto_library(
     name = "unpack_media_sequence_calculator_proto",

--- a/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.cc
+++ b/mediapipe/calculators/tensorflow/pack_media_sequence_calculator.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>// to keep the calculator buildable with newer Abseil/toolchains
 #include <cstdint>
 #include <limits>
 #include <optional>
@@ -52,6 +53,8 @@ const char kBBoxTag[] = "BBOX";
 const char kKeypointsTag[] = "KEYPOINTS";
 const char kSegmentationMaskTag[] = "CLASS_SEGMENTATION";
 const char kClipMediaIdTag[] = "CLIP_MEDIA_ID";
+const char kEncodedMediaStartTimestamp[] = "ENCODED_MEDIA_START_TIMESTAMP";//encoded-media tag constants 
+const char kEncodedMediaBytes[] = "ENCODED_MEDIA";
 
 namespace tf = ::tensorflow;
 namespace mpms = mediapipe::mediasequence;

--- a/mediapipe/calculators/video/tvl1_optical_flow_calculator.cc
+++ b/mediapipe/calculators/video/tvl1_optical_flow_calculator.cc
@@ -119,7 +119,7 @@ absl::Status Tvl1OpticalFlowCalculator::GetContract(CalculatorContract* cc) {
 
 absl::Status Tvl1OpticalFlowCalculator::Open(CalculatorContext* cc) {
   {
-    absl::MutexLock lock(mutex_);
+    absl::MutexLock lock(&mutex_);//Using pointer based to match Abseil's modren API
     tvl1_computers_.emplace_back(cv::createOptFlow_DualTVL1());
   }
   if (cc->Outputs().HasTag(kForwardFlowTag)) {
@@ -170,7 +170,7 @@ absl::Status Tvl1OpticalFlowCalculator::CalculateOpticalFlow(
   // creates a new DenseOpticalFlow.
   cv::Ptr<cv::DenseOpticalFlow> tvl1_computer;
   {
-    absl::MutexLock lock(mutex_);
+    absl::MutexLock lock(&mutex_);//Using pointer based to match Abseil's modren API
     if (!tvl1_computers_.empty()) {
       std::swap(tvl1_computer, tvl1_computers_.front());
       tvl1_computers_.pop_front();
@@ -186,7 +186,7 @@ absl::Status Tvl1OpticalFlowCalculator::CalculateOpticalFlow(
   ABSL_CHECK_EQ(flow->mutable_flow_data().data, cv_flow.data);
   // Inserts the idle DenseOpticalFlow object back to the cache for reuse.
   {
-    absl::MutexLock lock(mutex_);
+    absl::MutexLock lock(&mutex_);//Using pointer based to match Abseil's modren API
     tvl1_computers_.push_back(tvl1_computer);
   }
   return absl::OkStatus();

--- a/third_party/opencv_linux.BUILD
+++ b/third_party/opencv_linux.BUILD
@@ -15,17 +15,17 @@ cc_library(
     name = "opencv",
     hdrs = glob([
         # For OpenCV 4.x
-        #"include/aarch64-linux-gnu/opencv4/opencv2/cvconfig.h",
-        #"include/arm-linux-gnueabihf/opencv4/opencv2/cvconfig.h",
-        #"include/x86_64-linux-gnu/opencv4/opencv2/cvconfig.h",
-        #"include/opencv4/opencv2/**/*.h*",
+        "include/opencv4/opencv2/**/*.h*",
+        "include/x86_64-linux-gnu/opencv4/opencv2/**/*.h*",
+        "include/aarch64-linux-gnu/opencv4/opencv2/**/*.h*",
+        "include/arm-linux-gnueabihf/opencv4/opencv2/**/*.h*",
     ]),
     includes = [
         # For OpenCV 4.x
-        #"include/aarch64-linux-gnu/opencv4/",
-        #"include/arm-linux-gnueabihf/opencv4/",
-        #"include/x86_64-linux-gnu/opencv4/",
-        #"include/opencv4/",
+        "include/opencv4",
+        "include/x86_64-linux-gnu/opencv4",
+        "include/aarch64-linux-gnu/opencv4",
+        "include/arm-linux-gnueabihf/opencv4",
     ],
     linkopts = [
         "-l:libopencv_core.so",
@@ -36,6 +36,7 @@ cc_library(
         "-l:libopencv_imgproc.so",
         "-l:libopencv_video.so",
         "-l:libopencv_videoio.so",
+        "-l:libopencv_optflow.so",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
- Added `pack_media_sequence_calculator_proto` so Bazel can generate the missing *_cc_proto target
- Defined encoded-media tag constants and pulled in `<algorithm>` for `PackMediaSequenceCalculator`
- Updated TV-L1 optical flow locking to use pointer-based
- Exposed the OpenCV headers/libs from the system install
- Linked `libopencv_optflow.so` to satisfy the DualTVL1.

Steps i took to verify:
1.
```bash
bazel build //mediapipe/examples/desktop/media_sequence/...
```
2.
```bash
bazel run //mediapipe/examples/desktop/hello_world:hello_world
```
```shell
root@d52e01a5c39f:/workspace/mediapipe# bazel run //mediapipe/examples/desktop/hello_world:hello_world
INFO: Analyzed target //mediapipe/examples/desktop/hello_world:hello_world (3 packages loaded, 27 targets configured).
INFO: Found 1 target...
Target //mediapipe/examples/desktop/hello_world:hello_world up-to-date:
  bazel-bin/mediapipe/examples/desktop/hello_world/hello_world
INFO: Elapsed time: 7.438s, Critical Path: 6.74s
INFO: 8 processes: 5 internal, 3 processwrapper-sandbox.
INFO: Build completed successfully, 8 total actions
INFO: Running command line: bazel-bin/mediapipe/examples/desktop/hello_world/hello_world
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1761808941.910286    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.910466    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.910489    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.910509    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.910528    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.913578    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.913638    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.913653    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.913700    1697 hello_world.cc:58] Hello World!
I0000 00:00:1761808941.913735    1697 hello_world.cc:58] Hello World!
```