### PR TITLE
Upgrade zlib to version 1.3.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,9 +124,9 @@ http_archive(
     patches = [
         "@//third_party:zlib.diff",
     ],
-    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
-    strip_prefix = "zlib-1.2.13",
-    url = "http://zlib.net/fossils/zlib-1.2.13.tar.gz",
+    sha256 = "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23",
+    strip_prefix = "zlib-1.3.1",
+    url = "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
 )
 
 # gflags needed by glog


### PR DESCRIPTION
This PR is upgrading ZLIB version to allow compiling on newer CLANG and MacOS.