### PR TITLE
Fix: Update macOS OpenCV installation docs (Fixes #6091)

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -441,7 +441,7 @@ build issues.
     OpenCV 3 libraries. FFmpeg will be installed via OpenCV.
 
     ```bash
-    $ brew install opencv@3
+    $ brew install opencv
 
     # There is a known issue caused by the glog dependency. Uninstall glog.
     $ brew uninstall --ignore-dependencies glog


### PR DESCRIPTION
## Description
Fixes #6091

## Changes
Updated macOS OpenCV installation instructions to use the currently available `brew install opencv` command instead of the deprecated `brew install opencv@3`.

## Why
- `brew install opencv@3` formula has been removed from Homebrew as of 2024
- Users following the current documentation encounter errors
- `brew install opencv` installs the current version (opencv@4) which works with MediaPipe

## Type of Change
- [x] Documentation improvement
- [x] Bug fix
- [ ] New feature

## Testing
Documentation only - no code changes
