### PR TITLE
docs: fix outdated github.com/google/mediapipe URLs and typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/19-other-issues.md
+++ b/.github/ISSUE_TEMPLATE/19-other-issues.md
@@ -8,5 +8,5 @@ This template is for miscellaneous issues not covered by the other issue categor
 
 For questions on how to work with MediaPipe, or support for problems that are not verified bugs in MediaPipe, please go to [StackOverflow](https://stackoverflow.com/questions/tagged/mediapipe) and [Slack](https://mediapipe.page.link/joinslack) communities.
 
-If you are reporting a vulnerability, please use the [dedicated reporting process](https://github.com/google/mediapipe/security).
+If you are reporting a vulnerability, please use the [dedicated reporting process](https://github.com/google-ai-edge/mediapipe/security).
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ iOS), web, desktop, edge devices, and IoT, effortlessly.
 
 ## Get started
 
-You can get started with MediaPipe Solutions by by checking out any of the
+You can get started with MediaPipe Solutions by checking out any of the
 developer guides for
 [vision](https://developers.google.com/mediapipe/solutions/vision/object_detector),
 [text](https://developers.google.com/mediapipe/solutions/text/text_classifier),
@@ -46,7 +46,7 @@ apply artificial intelligence (AI) and machine learning (ML) techniques in your
 applications. You can plug these solutions into your applications immediately,
 customize them to your needs, and use them across multiple development
 platforms. MediaPipe Solutions is part of the MediaPipe [open source
-project](https://github.com/google/mediapipe), so you can further customize the
+project](https://github.com/google-ai-edge/mediapipe), so you can further customize the
 solutions code to meet your application needs.
 
 These libraries and resources provide the core functionality for each MediaPipe
@@ -71,11 +71,11 @@ These tools let you customize and evaluate solutions:
 We have ended support for [these MediaPipe Legacy Solutions](https://developers.google.com/mediapipe/solutions/guide#legacy)
 as of March 1, 2023. All other MediaPipe Legacy Solutions will be upgraded to
 a new MediaPipe Solution. See the [Solutions guide](https://developers.google.com/mediapipe/solutions/guide#legacy)
-for details. The [code repository](https://github.com/google/mediapipe/tree/master/mediapipe)
+for details. The [code repository](https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe)
 and prebuilt binaries for all MediaPipe Legacy Solutions will continue to be
 provided on an as-is basis.
 
-For more on the legacy solutions, see the [documentation](https://github.com/google/mediapipe/tree/master/docs/solutions).
+For more on the legacy solutions, see the [documentation](https://github.com/google-ai-edge/mediapipe/tree/master/docs/solutions).
 
 ## Framework
 
@@ -108,7 +108,7 @@ concepts](https://developers.google.com/mediapipe/framework/framework_concepts/o
 ## Contributing
 
 We welcome contributions. Please follow these
-[guidelines](https://github.com/google/mediapipe/blob/master/CONTRIBUTING.md).
+[guidelines](https://github.com/google-ai-edge/mediapipe/blob/master/CONTRIBUTING.md).
 
 We use GitHub issues for tracking requests and bugs. Please post questions to
 the MediaPipe Stack Overflow with a `mediapipe` tag.

--- a/docs/build_model_maker_api_docs.py
+++ b/docs/build_model_maker_api_docs.py
@@ -44,7 +44,7 @@ _OUTPUT_DIR = flags.DEFINE_string(
 
 _URL_PREFIX = flags.DEFINE_string(
     'code_url_prefix',
-    'https://github.com/google/mediapipe/tree/master/mediapipe/model_maker',
+    'https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe/model_maker',
     'The url prefix for links to code.')
 
 _SEARCH_HINTS = flags.DEFINE_bool(

--- a/docs/build_py_api_docs.py
+++ b/docs/build_py_api_docs.py
@@ -44,7 +44,7 @@ _OUTPUT_DIR = flags.DEFINE_string(
 
 _URL_PREFIX = flags.DEFINE_string(
     'code_url_prefix',
-    'https://github.com/google/mediapipe/blob/master/mediapipe',
+    'https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe',
     'The url prefix for links to code.')
 
 _SEARCH_HINTS = flags.DEFINE_bool(

--- a/docs/getting_started/android_archive_library.md
+++ b/docs/getting_started/android_archive_library.md
@@ -117,9 +117,9 @@ each project.
     Build the MediaPipe binary graph and copy the assets into
     app/src/main/assets, e.g., for the face detection graph, you need to build
     and copy
-    [the binary graph](https://github.com/google/mediapipe/blob/master/mediapipe/examples/android/src/java/com/google/mediapipe/apps/facedetectiongpu/BUILD#L41)
+    [the binary graph](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/examples/android/src/java/com/google/mediapipe/apps/facedetectiongpu/BUILD#L41)
     and
-    [the face detection tflite model](https://github.com/google/mediapipe/tree/master/mediapipe/modules/face_detection/face_detection_short_range.tflite).
+    [the face detection tflite model](https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe/modules/face_detection/face_detection_short_range.tflite).
 
     ```bash
     bazel build -c opt mediapipe/graphs/face_detection:face_detection_mobile_gpu_binary_graph

--- a/docs/getting_started/hello_world_cpp.md
+++ b/docs/getting_started/hello_world_cpp.md
@@ -26,7 +26,7 @@ as the primary developer documentation site for MediaPipe as of April 3, 2023.*
 2.  To run the [`hello world`] example:
 
     ```bash
-    $ git clone https://github.com/google/mediapipe.git
+    $ git clone https://github.com/google-ai-edge/mediapipe.git
     $ cd mediapipe
 
     $ export GLOG_logtostderr=1

--- a/docs/getting_started/help.md
+++ b/docs/getting_started/help.md
@@ -28,7 +28,7 @@ answers and support from the MediaPipe community.
 ## Bugs and feature requests
 
 To report bugs or make feature requests,
-[file an issue on GitHub](https://github.com/google/mediapipe/issues).
+[file an issue on GitHub](https://github.com/google-ai-edge/mediapipe/issues).
 
 If you open a GitHub issue, here is our policy:
 

--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -42,7 +42,7 @@ install --user six`.
 
     ```bash
     $ cd $HOME
-    $ git clone --depth 1 https://github.com/google/mediapipe.git
+    $ git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
 
     # Change directory into MediaPipe root directory
     $ cd mediapipe
@@ -301,7 +301,7 @@ build issues.
 2.  Checkout MediaPipe repository.
 
     ```bash
-    $ git clone --depth 1 https://github.com/google/mediapipe.git
+    $ git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
 
     # Change directory into MediaPipe root directory
     $ cd mediapipe
@@ -430,7 +430,7 @@ build issues.
 3.  Checkout MediaPipe repository.
 
     ```bash
-    $ git clone --depth 1 https://github.com/google/mediapipe.git
+    $ git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
 
     $ cd mediapipe
     ```
@@ -604,7 +604,7 @@ next section.
 7.  Checkout MediaPipe repository.
 
     ```
-    C:\Users\Username\mediapipe_repo> git clone --depth 1 https://github.com/google/mediapipe.git
+    C:\Users\Username\mediapipe_repo> git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
 
     # Change directory into MediaPipe root directory
     C:\Users\Username\mediapipe_repo> cd mediapipe
@@ -629,7 +629,7 @@ next section.
     Note: For building MediaPipe on Windows, please add `--action_env
     PYTHON_BIN_PATH="C://path//to//python.exe"` to the build command.
     Alternatively, you can follow
-    [issue 724](https://github.com/google/mediapipe/issues/724) to fix the
+    [issue 724](https://github.com/google-ai-edge/mediapipe/issues/724) to fix the
     python configuration manually.
 
     ```
@@ -694,7 +694,7 @@ cameras. Alternatively, you use a video file as input.
 6.  Checkout MediaPipe repository.
 
     ```bash
-    username@DESKTOP-TMVLBJ1:~$ git clone --depth 1 https://github.com/google/mediapipe.git
+    username@DESKTOP-TMVLBJ1:~$ git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
 
     username@DESKTOP-TMVLBJ1:~$ cd mediapipe
     ```
@@ -785,7 +785,7 @@ This will use a Docker image that will isolate mediapipe's installation from the
 2.  Build a docker image with tag "mediapipe".
 
     ```bash
-    $ git clone --depth 1 https://github.com/google/mediapipe.git
+    $ git clone --depth 1 https://github.com/google-ai-edge/mediapipe.git
     $ cd mediapipe
     $ docker build --tag=mediapipe .
 
@@ -866,9 +866,9 @@ common build issues.
     docker run -i -t mediapipe:latest
     ``` -->
 
-[`WORKSPACE`]: https://github.com/google/mediapipe/blob/master/WORKSPACE
-[`opencv_linux.BUILD`]: https://github.com/google/mediapipe/tree/master/third_party/opencv_linux.BUILD
-[`ffmpeg_linux.BUILD`]:https://github.com/google/mediapipe/tree/master/third_party/ffmpeg_linux.BUILD
-[`opencv_macos.BUILD`]: https://github.com/google/mediapipe/tree/master/third_party/opencv_macos.BUILD
-[`ffmpeg_macos.BUILD`]:https://github.com/google/mediapipe/tree/master/third_party/ffmpeg_macos.BUILD
-[`setup_opencv.sh`]: https://github.com/google/mediapipe/blob/master/setup_opencv.sh
+[`WORKSPACE`]: https://github.com/google-ai-edge/mediapipe/blob/master/WORKSPACE
+[`opencv_linux.BUILD`]: https://github.com/google-ai-edge/mediapipe/tree/master/third_party/opencv_linux.BUILD
+[`ffmpeg_linux.BUILD`]:https://github.com/google-ai-edge/mediapipe/tree/master/third_party/ffmpeg_linux.BUILD
+[`opencv_macos.BUILD`]: https://github.com/google-ai-edge/mediapipe/tree/master/third_party/opencv_macos.BUILD
+[`ffmpeg_macos.BUILD`]:https://github.com/google-ai-edge/mediapipe/tree/master/third_party/ffmpeg_macos.BUILD
+[`setup_opencv.sh`]: https://github.com/google-ai-edge/mediapipe/blob/master/setup_opencv.sh

--- a/docs/getting_started/ios.md
+++ b/docs/getting_started/ios.md
@@ -58,7 +58,7 @@ example apps, start from, start from
 5.  Clone the MediaPipe repository.
 
     ```bash
-    git clone https://github.com/google/mediapipe.git
+    git clone https://github.com/google-ai-edge/mediapipe.git
     ```
 
 ### Set up a bundle ID prefix
@@ -226,7 +226,7 @@ developer (yourself) is trusted.
     You may see a permission request from `codesign` in order to sign the app.
 
     Tip: If you are using custom provisioning, you can run this
-    [script](https://github.com/google/mediapipe/blob/master/build_ios_examples.sh)
+    [script](https://github.com/google-ai-edge/mediapipe/blob/master/build_ios_examples.sh)
     to build all MediaPipe iOS example apps.
 
 3.  In Xcode, open the `Devices and Simulators` window (command-shift-2).

--- a/docs/getting_started/troubleshooting.md
+++ b/docs/getting_started/troubleshooting.md
@@ -77,7 +77,7 @@ hosted by Google sites. In some regions, you may need to set up a network proxy
 or use a VPN to access those resources. You may also need to append
 `--host_jvm_args "-DsocksProxyHost=<ip address> -DsocksProxyPort=<port number>"`
 to the Bazel command. See
-[this GitHub issue](https://github.com/google/mediapipe/issues/581#issuecomment-610356857)
+[this GitHub issue](https://github.com/google-ai-edge/mediapipe/issues/581#issuecomment-610356857)
 for more details.
 
 If you believe that it's not a network issue, another possibility is that some
@@ -101,7 +101,7 @@ usually indicates that OpenCV is not properly configured for MediaPipe. Please
 take a look at the "Install OpenCV and FFmpeg" sections in
 [Installation](./install.md) to see how to modify MediaPipe's WORKSPACE and
 linux_opencv/macos_opencv/windows_opencv.BUILD files for your local opencv
-libraries. [This GitHub issue](https://github.com/google/mediapipe/issues/666)
+libraries. [This GitHub issue](https://github.com/google-ai-edge/mediapipe/issues/666)
 may also help.
 
 ## Python pip install failure

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ iOS), web, desktop, edge devices, and IoT, effortlessly.
 
 ## Get started
 
-You can get started with MediaPipe Solutions by by checking out any of the
+You can get started with MediaPipe Solutions by checking out any of the
 developer guides for
 [vision](https://developers.google.com/mediapipe/solutions/vision/object_detector),
 [text](https://developers.google.com/mediapipe/solutions/text/text_classifier),
@@ -46,7 +46,7 @@ apply artificial intelligence (AI) and machine learning (ML) techniques in your
 applications. You can plug these solutions into your applications immediately,
 customize them to your needs, and use them across multiple development
 platforms. MediaPipe Solutions is part of the MediaPipe [open source
-project](https://github.com/google/mediapipe), so you can further customize the
+project](https://github.com/google-ai-edge/mediapipe), so you can further customize the
 solutions code to meet your application needs.
 
 These libraries and resources provide the core functionality for each MediaPipe
@@ -71,11 +71,11 @@ These tools let you customize and evaluate solutions:
 We have ended support for [these MediaPipe Legacy Solutions](https://developers.google.com/mediapipe/solutions/guide#legacy)
 as of March 1, 2023. All other MediaPipe Legacy Solutions will be upgraded to
 a new MediaPipe Solution. See the [Solutions guide](https://developers.google.com/mediapipe/solutions/guide#legacy)
-for details. The [code repository](https://github.com/google/mediapipe/tree/master/mediapipe)
+for details. The [code repository](https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe)
 and prebuilt binaries for all MediaPipe Legacy Solutions will continue to be
 provided on an as-is basis.
 
-For more on the legacy solutions, see the [documentation](https://github.com/google/mediapipe/tree/master/docs/solutions).
+For more on the legacy solutions, see the [documentation](https://github.com/google-ai-edge/mediapipe/tree/master/docs/solutions).
 
 ## Framework
 
@@ -108,7 +108,7 @@ concepts](https://developers.google.com/mediapipe/framework/framework_concepts/o
 ## Contributing
 
 We welcome contributions. Please follow these
-[guidelines](https://github.com/google/mediapipe/blob/master/CONTRIBUTING.md).
+[guidelines](https://github.com/google-ai-edge/mediapipe/blob/master/CONTRIBUTING.md).
 
 We use GitHub issues for tracking requests and bugs. Please post questions to
 the MediaPipe Stack Overflow with a `mediapipe` tag.

--- a/docs/solutions/holistic.md
+++ b/docs/solutions/holistic.md
@@ -1,6 +1,6 @@
 ---
 layout: forward
-target: https://github.com/google/mediapipe/blob/master/docs/solutions/holistic.md
+target: https://github.com/google-ai-edge/mediapipe/blob/master/docs/solutions/holistic.md
 title: Holistic
 parent: MediaPipe Legacy Solutions
 nav_order: 6

--- a/docs/solutions/media_sequence.md
+++ b/docs/solutions/media_sequence.md
@@ -50,7 +50,7 @@ process new data sets, in the documentation of
 1.  Checkout the mediapipe repository
 
     ```bash
-    git clone https://github.com/google/mediapipe.git
+    git clone https://github.com/google-ai-edge/mediapipe.git
     cd mediapipe
     ```
 

--- a/docs/solutions/solutions.md
+++ b/docs/solutions/solutions.md
@@ -19,7 +19,7 @@ has_toc: false
 as of March 1, 2023. All other
 [MediaPipe Legacy Solutions will be upgraded](https://developers.google.com/mediapipe/solutions/guide#legacy)
 to a new MediaPipe Solution. The
-[code repository](https://github.com/google/mediapipe/tree/master/mediapipe)
+[code repository](https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe)
 and prebuilt binaries for all MediaPipe Legacy Solutions will continue to
 be provided on an as-is basis. We encourage you to check out the new MediaPipe
 Solutions at:

--- a/docs/solutions/youtube_8m.md
+++ b/docs/solutions/youtube_8m.md
@@ -59,11 +59,11 @@ videos.
 ### Steps to run the YouTube-8M feature extraction graph
 
 1.  Checkout the repository and follow
-    [the installation instructions](https://github.com/google/mediapipe/blob/master/mediapipe/docs/install.md)
+    [the installation instructions](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/docs/install.md)
     to set up MediaPipe.
 
     ```bash
-    git clone https://github.com/google/mediapipe.git
+    git clone https://github.com/google-ai-edge/mediapipe.git
     cd mediapipe
     ```
 

--- a/docs/tools/visualizer.md
+++ b/docs/tools/visualizer.md
@@ -90,9 +90,9 @@ the subgraph's definition.
 
 For instance, there are two graphs involved in
 [MediaPipe Hands](../solutions/hands.md): the main graph
-([source pbtxt file](https://github.com/google/mediapipe/blob/master/mediapipe/graphs/hand_tracking/hand_detection_mobile.pbtxt))
+([source pbtxt file](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/graphs/hand_tracking/hand_detection_mobile.pbtxt))
 and its associated subgraph
-([source pbtxt file](https://github.com/google/mediapipe/blob/master/mediapipe/graphs/hand_tracking/subgraphs/hand_detection_gpu.pbtxt)).
+([source pbtxt file](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/graphs/hand_tracking/subgraphs/hand_detection_gpu.pbtxt)).
 To visualize them:
 
 *   In the MediaPipe visualizer, click on the upload graph button and select the

--- a/mediapipe/examples/desktop/autoflip/README.md
+++ b/mediapipe/examples/desktop/autoflip/README.md
@@ -1,11 +1,11 @@
 ### Steps to run the AutoFlip video cropping graph
 
 1.  Checkout the repository and follow
-    [the installation instructions](https://github.com/google/mediapipe/blob/master/mediapipe/docs/install.md)
+    [the installation instructions](https://github.com/google-ai-edge/mediapipe/blob/master/mediapipe/docs/install.md)
     to set up MediaPipe.
 
     ```bash
-    git clone https://github.com/google/mediapipe.git
+    git clone https://github.com/google-ai-edge/mediapipe.git
     cd mediapipe
     ```
 

--- a/mediapipe/examples/desktop/youtube8m/README.md
+++ b/mediapipe/examples/desktop/youtube8m/README.md
@@ -1,11 +1,11 @@
 ### Steps to run the YouTube-8M feature extraction graph
 
 1.  Checkout the repository and follow
-    [the installation instructions](https://github.com/google/mediapipe/blob/master/docs/getting_started/install.md)
+    [the installation instructions](https://github.com/google-ai-edge/mediapipe/blob/master/docs/getting_started/install.md)
     to set up MediaPipe.
 
     ```bash
-    git clone https://github.com/google/mediapipe.git
+    git clone https://github.com/google-ai-edge/mediapipe.git
     cd mediapipe
     ```
 

--- a/mediapipe/model_maker/python/vision/gesture_recognizer/metadata_writer.py
+++ b/mediapipe/model_maker/python/vision/gesture_recognizer/metadata_writer.py
@@ -50,7 +50,7 @@ class GestureClassifierOptions:
     score_thresholding: Parameters to performs thresholding on output tensor
       values [1].
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
   """
   model_buffer: bytearray
   labels: metadata_writer.Labels

--- a/mediapipe/model_maker/setup.py
+++ b/mediapipe/model_maker/setup.py
@@ -73,7 +73,7 @@ _setup_build_dir()
 setuptools.setup(
     name='mediapipe-model-maker',
     version=__version__,
-    url='https://github.com/google/mediapipe/tree/master/mediapipe/model_maker',
+    url='https://github.com/google-ai-edge/mediapipe/tree/master/mediapipe/model_maker',
     description='MediaPipe Model Maker is a simple, low-code solution for customizing on-device ML models',
     author='The MediaPipe Authors',
     author_email='mediapipe@google.com',

--- a/mediapipe/tasks/python/metadata/metadata.py
+++ b/mediapipe/tasks/python/metadata/metadata.py
@@ -917,7 +917,7 @@ def convert_to_json(
       custom metadata name [1], value is the filepath that defines custom
       metadata schema. For instance, custom_metadata_schema =
       {"SEGMENTER_METADATA": "metadata/vision_tasks_metadata_schema.fbs"}. [1]:
-        https://github.com/google/mediapipe/blob/46b5c4012d2ef76c9d92bb0d88a6b107aee83814/mediapipe/tasks/metadata/metadata_schema.fbs#L612
+        https://github.com/google-ai-edge/mediapipe/blob/46b5c4012d2ef76c9d92bb0d88a6b107aee83814/mediapipe/tasks/metadata/metadata_schema.fbs#L612
 
   Returns:
     Metadata in JSON format.

--- a/mediapipe/tasks/python/metadata/metadata_writers/image_classifier.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/image_classifier.py
@@ -55,11 +55,11 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
         calibration.
 
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
       [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
 
     Returns:
       A MetadataWriter object.

--- a/mediapipe/tasks/python/metadata/metadata_writers/image_segmenter.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/image_segmenter.py
@@ -140,9 +140,9 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
         tensor [2].
       activation: activation function for the output layer.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L116
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L116
 
     Returns:
       A MetadataWriter object.

--- a/mediapipe/tasks/python/metadata/metadata_writers/metadata_info.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/metadata_info.py
@@ -81,9 +81,9 @@ class AssociatedFileMd:
     file_type: file type of the associated file [1].
     locale: locale of the associated file [2].
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L77
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L77
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L176
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L176
   """
 
   def __init__(
@@ -125,7 +125,7 @@ class LabelFileMd(AssociatedFileMd):
       file_path: file_path of the label file.
       locale: locale of the label file [1].
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L176
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L176
     """
     super().__init__(file_path, self._LABEL_FILE_DESCRIPTION, self._FILE_TYPE,
                      locale)
@@ -135,7 +135,7 @@ class ScoreCalibrationMd:
   """A container for score calibration [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
   """
 
   _SCORE_CALIBRATION_FILE_DESCRIPTION = (
@@ -157,7 +157,7 @@ class ScoreCalibrationMd:
         index.
       file_path: file_path of the score calibration file [1].
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L133
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L133
 
     Raises:
       ValueError: if the score_calibration file is malformed.
@@ -205,7 +205,7 @@ class ScoreThresholdingMd:
   """A container for score thresholding [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
   """
 
   def __init__(self, global_score_threshold: float) -> None:
@@ -236,7 +236,7 @@ class RegexTokenizerMd:
   """A container for the Regex tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
   """
 
   def __init__(self, delim_regex_pattern: str, vocab_file_path: str):
@@ -275,7 +275,7 @@ class BertTokenizerMd:
   """A container for the Bert tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
   """
 
   def __init__(self, vocab_file_path: str):
@@ -307,7 +307,7 @@ class SentencePieceTokenizerMd:
   """A container for the sentence piece tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
   """
 
   _SP_MODEL_DESCRIPTION = "The sentence piece model file."
@@ -383,9 +383,9 @@ class TensorMd:
     [1]:
       https://github.com/tensorflow/tensorflow/blob/cb67fef35567298b40ac166b0581cd8ad68e5a3a/tensorflow/lite/schema/schema.fbs#L1129-L1136
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L623-L640
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L623-L640
     [3]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
   """
 
   def __init__(
@@ -459,9 +459,9 @@ class InputImageTensorMd(TensorMd):
       norm_std must have the same dimension.
     color_space_type: the color space type of the input image [2].
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
   """
 
   # Min and max float values for image pixels.
@@ -487,9 +487,9 @@ class InputImageTensorMd(TensorMd):
       color_space_type: the color space type of the input image [2].
       tensor_type: data type of the tensor.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
 
     Raises:
       ValueError: if norm_mean and norm_std have different dimensions.
@@ -564,11 +564,11 @@ class InputTextTensorMd(TensorMd):
         is `BertTokenizer` [2] or `SentencePieceTokenizer` [3], refer to
         `BertInputTensorsMd` class.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
       [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
     """
     super().__init__(name, description)
     self.tokenizer_md = tokenizer_md
@@ -611,9 +611,9 @@ def _get_tokenizer_associated_files(
     tokenizer_options: a tokenizer metadata object. Support the following
       tokenizer types:
       1. BertTokenizerOptions:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
       2. SentencePieceTokenizerOptions:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
 
   Returns:
     A list of associated files included in tokenizer_options.
@@ -743,11 +743,11 @@ class ClassificationTensorMd(TensorMd):
     score_thresholding_md: information of the score thresholding [3] in the
         classification tensor.
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
     [3]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
   """
 
   # Min and max float values for classification results.
@@ -782,17 +782,17 @@ class ClassificationTensorMd(TensorMd):
         classification tensor.
       content_range_md: information of content range [6].
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
       [3]:
         https://github.com/tensorflow/tensorflow/blob/cb67fef35567298b40ac166b0581cd8ad68e5a3a/tensorflow/lite/schema/schema.fbs#L1129-L1136
       [4]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L623-L640
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L623-L640
       [5]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
       [6]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
     """
     self.score_calibration_md = score_calibration_md
     self.score_thresholding_md = score_thresholding_md
@@ -896,9 +896,9 @@ class CategoryTensorMd(TensorMd):
       label_files: information of the label files [1] in the category tensor.
       content_range_md: information of content range [2].
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L116
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L116
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L385
     """
     # In category tensors, label files are in the type of TENSOR_VALUE_LABELS.
     if label_files:
@@ -941,9 +941,9 @@ class DetectionOutputTensorsMd:
       score_calibration_md: information of the score calibration files operation
         [2] in the classification tensor.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
     """
     content_range_md = ValueRangeMd(
         min_value=self._CONTENT_VALUE_DIM, max_value=self._CONTENT_VALUE_DIM
@@ -1043,7 +1043,7 @@ class RawDetectionOutputTensorsMd:
         tensor.
       output_tensors_order: the order of the output tensors.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L9
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L9
     """
     # Get the output tensor indices and names from the tflite model.
     tensor_indices_and_names = list(
@@ -1096,7 +1096,7 @@ class TensorGroupMd:
       tensor_names:  Names of the tensors to group together, corresponding to
         TensorMetadata.name [1].
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L564
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L564
     """
     self.name = name
     self.tensor_names = tensor_names
@@ -1145,7 +1145,7 @@ class SegmentationMaskMd(TensorMd):
         _metadata_fb.ContentProperties.ImageProperties
     )
     # Add the content range. See
-    # https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L323-L385
+    # https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L323-L385
     dim_range = _metadata_fb.ValueRangeT()
     dim_range.min = self._CONTENT_DIM_MIN
     dim_range.max = self._CONTENT_DIM_MAX

--- a/mediapipe/tasks/python/metadata/metadata_writers/metadata_writer.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/metadata_writer.py
@@ -60,7 +60,7 @@ class CalibrationParameter:
       been specified.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L434
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L434
   """
   scale: float
   slope: float
@@ -89,7 +89,7 @@ class ScoreThresholding:
   Attributes:
     global_score_threshold: The recommended global threshold below which results
       are considered low-confidence and should be filtered out.  [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L468
   """
   global_score_threshold: float
 
@@ -99,7 +99,7 @@ class RegexTokenizer:
   """Parameters of the Regex tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
 
   Attributes:
     delim_regex_pattern: the regular expression to segment strings and create
@@ -115,7 +115,7 @@ class BertTokenizer:
   """Parameters of the Bert tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
 
   Attributes:
     vocab_file_path: path to the vocabulary file.
@@ -128,7 +128,7 @@ class SentencePieceTokenizer:
   """Parameters of the sentence piece tokenizer tokenizer [1] metadata information.
 
   [1]:
-    https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+    https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
 
   Attributes:
     sentence_piece_model_path: path to the sentence piece model file.
@@ -244,7 +244,7 @@ class ScoreCalibration:
         score is below min_score or if no parameters were specified for a given
         index.
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L133
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L133
       [2]:
         https://en.cppreference.com/w/c/string/byte/strtof
 
@@ -335,9 +335,9 @@ def _create_metadata_buffer(
     output_group_md: a list of metadata of output tensor groups [2];
     custom_metadata_md: a lists of custom metadata.
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L655
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L655
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L677
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L677
 
   Returns:
     A buffer of the metadata.
@@ -480,9 +480,9 @@ class MetadataWriter(object):
       The MetadataWriter instance, can be used for chained operation.
 
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L198
     """
     input_md = metadata_info.InputImageTensorMd(
         name=name,
@@ -512,7 +512,7 @@ class MetadataWriter(object):
       The MetadataWriter instance, can be used for chained operation.
 
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
     """
     tokenizer_md = metadata_info.RegexTokenizerMd(
         delim_regex_pattern=regex_tokenizer.delim_regex_pattern,
@@ -552,9 +552,9 @@ class MetadataWriter(object):
         SentencePieceTokenizer.
 
     [1]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
     [2]:
-      https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+      https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
     """
     if isinstance(tokenizer, BertTokenizer):
       tokenizer_md = metadata_info.BertTokenizerMd(

--- a/mediapipe/tasks/python/metadata/metadata_writers/object_detector.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/object_detector.py
@@ -248,11 +248,11 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       [1]:
         https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/detection_postprocess.cc
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
       [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
       [4]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L456
 
     Returns:
       A MetadataWriter object.
@@ -305,9 +305,9 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
       [1]:
         https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/detection_postprocess.cc
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L389
       [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
 
     Returns:
       A MetadataWriter object.

--- a/mediapipe/tasks/python/metadata/metadata_writers/text_classifier.py
+++ b/mediapipe/tasks/python/metadata/metadata_writers/text_classifier.py
@@ -53,13 +53,13 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
         classification tensor [4].
 
       [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
       [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
       [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
       [4]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
 
     Returns:
       A MetadataWriter object.
@@ -101,13 +101,13 @@ class MetadataWriter(metadata_writer.MetadataWriterBase):
         real tokens and `0` for padding tokens.
       segment_name: name of the segment ids tensor, where `0` stands for the
         first sequence, and `1` stands for the second sequence if exists. [1]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L477
           [2]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L485
           [3]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L500
           [4]:
-        https://github.com/google/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
+        https://github.com/google-ai-edge/mediapipe/blob/f8af41b1eb49ff4bdad756ff19d1d36f486be614/mediapipe/tasks/metadata/metadata_schema.fbs#L99
 
     Returns:
       A MetadataWriter object.

--- a/mediapipe/tasks/python/vision/image_classifier.py
+++ b/mediapipe/tasks/python/vision/image_classifier.py
@@ -204,7 +204,7 @@ class ImageClassifier:
   https://tfhub.dev/bohemian-visual-recognition-alliance/lite-model/models/mushroom-identification_v1/1
 
   [1]:
-  https://github.com/google/mediapipe/blob/6cdc6443b6a7ed662744e2a2ce2d58d9c83e6d6f/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+  https://github.com/google-ai-edge/mediapipe/blob/6cdc6443b6a7ed662744e2a2ce2d58d9c83e6d6f/mediapipe/tasks/metadata/metadata_schema.fbs#L456
   """
 
   _lib: serial_dispatcher.SerialDispatcher

--- a/mediapipe/tasks/python/vision/object_detector.py
+++ b/mediapipe/tasks/python/vision/object_detector.py
@@ -250,7 +250,7 @@ class ObjectDetector:
   https://tfhub.dev/google/lite-model/object_detection/mobile_object_localizer_v1/1/metadata/1
 
   [1]:
-  https://github.com/google/mediapipe/blob/6cdc6443b6a7ed662744e2a2ce2d58d9c83e6d6f/mediapipe/tasks/metadata/metadata_schema.fbs#L456
+  https://github.com/google-ai-edge/mediapipe/blob/6cdc6443b6a7ed662744e2a2ce2d58d9c83e6d6f/mediapipe/tasks/metadata/metadata_schema.fbs#L456
   """
 
   _lib: serial_dispatcher.SerialDispatcher

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def _get_long_description():
   # Fix the image urls.
   return re.sub(
       r'(docs/images/|docs/images/mobile/)([A-Za-z0-9_]*\.(png|gif))',
-      r'https://github.com/google/mediapipe/blob/master/\g<1>\g<2>?raw=true',
+      r'https://github.com/google-ai-edge/mediapipe/blob/master/\g<1>\g<2>?raw=true',
       open(os.path.join(MP_ROOT_PATH, 'README.md'),
            'rb').read().decode('utf-8'))
 
@@ -347,7 +347,7 @@ class Restore(setuptools.Command):
 setuptools.setup(
     name='mediapipe',
     version=__version__,
-    url='https://github.com/google/mediapipe',
+    url='https://github.com/google-ai-edge/mediapipe',
     description=(
         'MediaPipe is the simplest way for researchers and developers to build'
         ' world-class ML solutions and applications for mobile, edge, cloud and'


### PR DESCRIPTION
## Description

This PR updates all references from the old repository URL (`github.com/google/mediapipe`) to the current URL (`github.com/google-ai-edge/mediapipe`) across 30 documentation and source files. It also fixes a duplicate-word typo (`by by` → `by`) in `README.md` and `docs/index.md`.

## Changes

### 1. Outdated GitHub org URLs (30 files, 117 instances)

All occurrences of `github.com/google/mediapipe` have been updated to `github.com/google-ai-edge/mediapipe` in:

- **Root files**: `README.md`, `setup.py`
- **Docs**: `docs/index.md`, `docs/getting_started/*.md`, `docs/solutions/*.md`, `docs/tools/visualizer.md`, `docs/build_*_api_docs.py`
- **Issue templates**: `.github/ISSUE_TEMPLATE/19-other-issues.md`
- **Example READMEs**: `mediapipe/examples/desktop/autoflip/README.md`, `mediapipe/examples/desktop/youtube8m/README.md`
- **Python source** (comments/docstrings): `mediapipe/tasks/python/metadata/*.py`, `mediapipe/tasks/python/vision/*.py`, `mediapipe/model_maker/setup.py`, `mediapipe/model_maker/python/vision/gesture_recognizer/metadata_writer.py`

### 2. Typo fix

`README.md` line 30 and `docs/index.md` line 30: `"by by checking"` → `"by checking"`

## Checklist

- [x] Read [contributing guidelines](https://github.com/google-ai-edge/mediapipe/blob/master/CONTRIBUTING.md)
- [x] Read [Code of Conduct](https://github.com/google-ai-edge/mediapipe/blob/master/CODE_OF_CONDUCT.md)
- [x] This is a documentation fix (accepted PR type)
- [x] Changes are minimal and safe (text-only URL and typo corrections)
- [x] Verified locally: `grep -rn 'github.com/google/mediapipe'` returns 0 results after the fix