### PR TITLE
Fix R8 stripping JNI callback methods causing SIGABRT

### DIFF
--- a/mediapipe/java/com/google/mediapipe/framework/proguard.pgcfg
+++ b/mediapipe/java/com/google/mediapipe/framework/proguard.pgcfg
@@ -1,11 +1,23 @@
 # Additional flags to pass to Proguard when processing a binary that uses
 # MediaPipe.
 
-# Keep public members of our public interfaces. This also prevents the
-# obfuscation of the corresponding methods in classes implementing them,
-# such as implementations of PacketCallback#process.
+# Keep public members of our public interfaces.
 -keep public interface com.google.mediapipe.framework.* {
   public *;
+}
+
+# Keep process() on all callback implementations including lambda-desugared
+# anonymous classes. R8 cannot see that these methods are invoked via JNI
+# (graph.cc CallbackToJava) and will strip them, causing a fatal SIGABRT when
+# GetMethodID fails at runtime. See #6045.
+-keep class * implements com.google.mediapipe.framework.PacketCallback {
+  void process(com.google.mediapipe.framework.Packet);
+}
+-keep class * implements com.google.mediapipe.framework.PacketListCallback {
+  void process(java.util.List);
+}
+-keep class * implements com.google.mediapipe.framework.PacketWithHeaderCallback {
+  void process(com.google.mediapipe.framework.Packet, com.google.mediapipe.framework.Packet);
 }
 
 # This method is invoked by native code.


### PR DESCRIPTION
## Summary

Fixes #6045 — Android apps using MediaPipe tasks with R8 minification (`isMinifyEnabled = true`) crash with a fatal `SIGABRT` when running inference (e.g. `ImageSegmenter.segment()`).

**Root cause:** R8 tree-shakes `process()` method implementations on lambda-desugared anonymous classes that implement `PacketCallback`, `PacketListCallback`, or `PacketWithHeaderCallback`. R8 cannot see that these methods are invoked from native JNI code (`graph.cc` `CallbackToJava` → `GetMethodID` → `CallVoidMethod`), so it considers them dead code and strips them. When `GetMethodID` fails to find the method at runtime, the JNI layer triggers a hard `SIGABRT` that bypasses try/catch.

The existing ProGuard rule `-keep public interface com.google.mediapipe.framework.* { public *; }` preserves the interface definitions but does **not** prevent R8 from removing method implementations on anonymous/synthetic classes.

**Fix:** Add explicit `-keep class * implements <Interface>` rules for the three callback interfaces so R8 retains `process()` on all implementing classes, including lambda-desugared synthetics.

## Changes

- `mediapipe/java/com/google/mediapipe/framework/proguard.pgcfg` — Added keep rules for:
  - `PacketCallback.process(Packet)`
  - `PacketListCallback.process(List)`
  - `PacketWithHeaderCallback.process(Packet, Packet)`

## Reproduction

Minimal repro from the issue reporter: https://github.com/rvp-diconium/mediapipe-bug-report

```kotlin
val segmenter = ImageSegmenter.createFromOptions(context, options)
segmenter.segment(inputImage).confidenceMasks() // SIGABRT here with R8 enabled
```

Logcat shows:
```
JNI DETECTED ERROR IN APPLICATION: JNI GetMethodID called with pending exception java.lang.NoSuchMethodError
```

## Test plan

- [ ] Build the `mediapipe_aar` target and verify the updated `proguard.pgcfg` is bundled
- [ ] Build the minimal repro app (linked above) with `isMinifyEnabled = true` against the patched AAR
- [ ] Verify `ImageSegmenter.segment()` completes without crash
- [ ] Verify the same with `PacketCallback` (single-stream) and `PacketWithHeaderCallback` callbacks