### PR TITLE
docs: update macOS OpenCV install command (fixes #6091)

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -438,14 +438,17 @@ build issues.
 4.  Install OpenCV and FFmpeg.
 
     Option 1. Use HomeBrew package manager tool to install the pre-compiled
-    OpenCV 3 libraries. FFmpeg will be installed via OpenCV.
+    OpenCV libraries. FFmpeg will be installed via OpenCV.
 
     ```bash
-    $ brew install opencv@3
+    $ brew install opencv
 
     # There is a known issue caused by the glog dependency. Uninstall glog.
     $ brew uninstall --ignore-dependencies glog
     ```
+
+    Note: The `opencv@3` formula has been removed from Homebrew. The command
+    above now installs OpenCV 4.x, which is compatible with MediaPipe.
 
     Option 2. Use MacPorts package manager tool to install the OpenCV libraries.
 


### PR DESCRIPTION
## Summary

Fixes #6091 

Updates the macOS installation docs to use `brew install opencv` instead of `brew install opencv@3`, as the opencv@3 formula has been removed from Homebrew.

## Changes

- Changed Homebrew command from `brew install opencv@3` to `brew install opencv`
- Added note explaining that opencv@3 formula is no longer available
- Clarified that the command now installs OpenCV 4.x, which is compatible with MediaPipe
- Updated description from "OpenCV 3 libraries" to "OpenCV libraries"

## Testing

- Verified that `brew install opencv` works on macOS (installs OpenCV 4.x)
- Confirmed OpenCV 4.x compatibility statement in existing docs (top of install.md)

## Impact

This unblocks macOS users who were unable to follow the official installation guide due to the missing opencv@3 formula. OpenCV 4.x (installed via `brew install opencv`) is already noted as compatible at the top of the document.

---

**Documentation change only** - no code changes required.