### PR TITLE
Fix zlib OS_CODE misidentification on non-macOS Apple platforms 

### DIFF
--- a/third_party/zlib.diff
+++ b/third_party/zlib.diff
@@ -1,3 +1,15 @@
+diff -ruN a/zutil.h b/zutil.h
+--- a/zutil.h
++++ b/zutil.h
+@@ -138,7 +138,7 @@
+ #  endif
+ #endif
+
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 diff -ruN a/contrib/minizip/ioapi.h b/contrib/minizip/ioapi.h
 --- a/contrib/minizip/ioapi.h
 +++ b/contrib/minizip/ioapi.h


### PR DESCRIPTION
The `zutil.h` patch in `third_party/zlib.diff` currently checks `defined(MACOS) || defined(TARGET_OS_MAC)` to set `OS_CODE` to 7 (Macintosh). However, `TARGET_OS_MAC` is defined as 1 for **all** Apple       
  platforms (macOS, iOS, tvOS, watchOS, visionOS) in the Apple SDK headers, not just macOS.                                                                                                                      
                                                                                                                                                                                                                 
  This causes iOS and other non-macOS Apple platform builds to incorrectly use `OS_CODE 7` and pull in classic Mac-specific code paths (e.g., `macopen()` via `__MWERKS__` checks), which are not appropriate for
   these platforms.                                                                                                                                                                                              
                                                                                                                                                                                                                 
  This change removes the `TARGET_OS_MAC` check, keeping only `defined(MACOS)` which correctly targets classic Mac OS only.