### PR TITLE
fix: prevent path traversal in tarfile.extractall() (CWE-22)

### DIFF
--- a/mediapipe/model_maker/python/core/utils/file_util.py
+++ b/mediapipe/model_maker/python/core/utils/file_util.py
@@ -74,6 +74,17 @@ class DownloadedFiles:
         tarf = tarfile.open(tempf.name)
         # Use tmpdir to store the extracted contents of the .tar.gz file
         with tempfile.TemporaryDirectory() as tmpdir:
+          # Security fix: use filter='data' to prevent path traversal (CWE-22)
+          # See: https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter
+          # Python <3.12 backwards-compatible approach used below
+          for member in tarf.getmembers():
+            import os as _os
+            member_path = _os.path.join(tmpdir, member.name)
+            abs_path = _os.path.realpath(member_path)
+            if not abs_path.startswith(_os.path.realpath(tmpdir) + _os.sep):
+              raise RuntimeError(
+                  f'Attempted path traversal in tar file: {member.name}'
+              )
           tarf.extractall(tmpdir)
           tarf.close()
           tempf.close()


### PR DESCRIPTION
## Summary

`DownloadedFiles.get_path()` in `mediapipe/model_maker/python/core/utils/file_util.py` calls `tarf.extractall(tmpdir)` without validating member paths. A crafted tar.gz with `../` path traversal members can escape the temp directory and write files to arbitrary locations on the filesystem.

## Root Cause

```python
# Vulnerable (current):
tarf.extractall(tmpdir)  # No path validation

# Fixed (this PR):
for member in tarf.getmembers():
    member_path = os.path.join(tmpdir, member.name)
    abs_path = os.path.realpath(member_path)
    if not abs_path.startswith(os.path.realpath(tmpdir) + os.sep):
        raise RuntimeError(f'Attempted path traversal in tar file: {member.name}')
tarf.extractall(tmpdir)
```

## Impact

Without validation, a tar.gz archive with `../model_maker/...` members can pre-populate the persistent model cache at `/tmp/model_maker/`. Subsequent calls to `get_path()` skip the download and return the poisoned path.

Affected: all `DownloadedFiles` instances with `is_folder=True` (gesture_recognizer, object_detector, loss_functions).

## References

- CWE-22: Improper Limitation of a Pathname to a Restricted Directory
- CVE-2007-4559: Python tarfile path traversal (same class)
- PEP 706: https://peps.python.org/pep-0706/
- Python docs: https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter

## Tested

Verified against `poc_cache_poison_full_chain.py` — fix prevents path traversal members from escaping the temp directory.