### PR TITLE
genai converter: reject path-traversal in safetensors tensor names

### DIFF
--- a/mediapipe/tasks/python/genai/converter/tests/weight_bins_writer_path_safety_test.py
+++ b/mediapipe/tasks/python/genai/converter/tests/weight_bins_writer_path_safety_test.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+"""Regression tests for path-traversal hardening in weight_bins_writer.
+
+Exercises the real weight_bins_writer._safe_join. Before importing the
+module, we register placeholder packages in sys.modules so that
+absolute imports inside weight_bins_writer resolve to our stubs
+instead of triggering mediapipe.tasks.python.__init__, which eagerly
+imports cv2, matplotlib, and jax for unrelated vision utilities.
+"""
+
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+
+
+def _load_real_weight_bins_writer():
+  """Load weight_bins_writer.py directly, shortcutting package __init__."""
+  src = (pathlib.Path(__file__).resolve().parent.parent
+         / "weight_bins_writer.py")
+
+  # Register placeholder packages for each level of the import path so
+  # `from mediapipe.tasks.python.genai.converter import ...` inside
+  # weight_bins_writer.py finds an already-initialised package and does
+  # not execute the real __init__.py chain.
+  pkg_names = [
+      "mediapipe",
+      "mediapipe.tasks",
+      "mediapipe.tasks.python",
+      "mediapipe.tasks.python.genai",
+      "mediapipe.tasks.python.genai.converter",
+  ]
+  for name in pkg_names:
+    if name not in sys.modules:
+      placeholder = types.ModuleType(name)
+      placeholder.__path__ = []  # mark as package
+      sys.modules[name] = placeholder
+
+  # Minimal base class so `class WeightBinsWriter(converter_base.ModelWriterBase)`
+  # resolves at class-definition time.
+  class _ModelWriterBaseStub:
+    def __init__(self, *args, **kwargs):
+      pass
+
+  stubs = {
+      "mediapipe.tasks.python.genai.converter.converter_base": {
+          "ModelWriterBase": _ModelWriterBaseStub,
+      },
+      "mediapipe.tasks.python.genai.converter.external_dependencies": {
+          "jnp": None,
+      },
+      "mediapipe.tasks.python.genai.converter.quantization_util": {},
+  }
+  for stub_name, attrs in stubs.items():
+    mod = types.ModuleType(stub_name)
+    for k, v in attrs.items():
+      setattr(mod, k, v)
+    sys.modules[stub_name] = mod
+
+  spec = importlib.util.spec_from_file_location(
+      "mediapipe.tasks.python.genai.converter.weight_bins_writer", src)
+  mod = importlib.util.module_from_spec(spec)
+  sys.modules[
+      "mediapipe.tasks.python.genai.converter.weight_bins_writer"] = mod
+  spec.loader.exec_module(mod)
+  return mod
+
+
+wbw = _load_real_weight_bins_writer()
+
+
+class PathSafetyTest(unittest.TestCase):
+
+  def setUp(self):
+    self._tmp = tempfile.TemporaryDirectory()
+    self.addCleanup(self._tmp.cleanup)
+    self.output_dir = self._tmp.name
+
+  def test_relative_traversal_rejected(self):
+    with self.assertRaises(ValueError):
+      wbw._safe_join(self.output_dir, "../escape.bin")
+
+  def test_absolute_path_rejected(self):
+    with self.assertRaises(ValueError):
+      wbw._safe_join(self.output_dir, "/tmp/escape.bin")
+
+  def test_deep_traversal_rejected(self):
+    with self.assertRaises(ValueError):
+      wbw._safe_join(self.output_dir, "../../../../../tmp/escape.bin")
+
+  def test_embedded_separator_rejected(self):
+    with self.assertRaises(ValueError):
+      wbw._safe_join(self.output_dir, "subdir/file.bin")
+
+  def test_backslash_separator_rejected(self):
+    with self.assertRaises(ValueError):
+      wbw._safe_join(self.output_dir, "subdir\\file.bin")
+
+  def test_safe_names_accepted(self):
+    for name in ["layer0.w", "emb-table_1.bin", "alpha-beta", "a.b.c"]:
+      got = wbw._safe_join(self.output_dir, name)
+      self.assertTrue(got.startswith(os.path.realpath(self.output_dir)))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/mediapipe/tasks/python/genai/converter/weight_bins_writer.py
+++ b/mediapipe/tasks/python/genai/converter/weight_bins_writer.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import os
+import re
 from typing import Dict, Tuple
 
 import numpy as np
@@ -25,6 +26,34 @@ from mediapipe.tasks.python.genai.converter import external_dependencies
 from mediapipe.tasks.python.genai.converter import quantization_util
 
 jnp = external_dependencies.jnp
+
+
+# Tensor-name whitelist: letters, digits, dot, underscore, hyphen only.
+# Anything else (including path separators and traversal tokens) is
+# rejected before a path is joined. Crafted .safetensors JSON headers
+# have put "../" and absolute paths in tensor names as a path-traversal
+# arbitrary-file-write primitive.
+_SAFE_TENSOR_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_join(output_dir: str, var_name: str) -> str:
+  """Join output_dir and var_name, rejecting any name that escapes output_dir.
+
+  Raises ValueError on traversal tokens, absolute paths, embedded path
+  separators, or on a resolved path that lies outside output_dir.
+  """
+  if not _SAFE_TENSOR_NAME_RE.match(var_name):
+    raise ValueError(
+        f"unsafe tensor name {var_name!r}: must match "
+        f"{_SAFE_TENSOR_NAME_RE.pattern}"
+    )
+  base = os.path.realpath(output_dir)
+  candidate = os.path.realpath(os.path.join(base, var_name))
+  if os.path.commonpath([candidate, base]) != base:
+    raise ValueError(
+        f"tensor name {var_name!r} escapes output_dir {output_dir!r}"
+    )
+  return candidate
 
 
 @contextlib.contextmanager
@@ -93,14 +122,14 @@ class WeightBinsWriter(converter_base.ModelWriterBase):
         else:  # LoRA right weight is shared across q, k, v
           weight_q = weight_k = weight_v = output
           weights_info.append(self.get_weight_info(var_name_q, weight_q))
-        path_q = os.path.join(self._output_dir, var_name_q)
+        path_q = _safe_join(self._output_dir, var_name_q)
         with filemanager(path_q, 'wb') as f:
           f.write(weight_q.tobytes())
           weights_info.append(self.get_weight_info(var_name_k, weight_k))
-        path_k = os.path.join(self._output_dir, var_name_k)
+        path_k = _safe_join(self._output_dir, var_name_k)
         with filemanager(path_k, 'wb') as f:
           f.write(weight_k.tobytes())
-        path_v = os.path.join(self._output_dir, var_name_v)
+        path_v = _safe_join(self._output_dir, var_name_v)
         with filemanager(path_v, 'wb') as f:
           f.write(weight_v.tobytes())
           weights_info.append(self.get_weight_info(var_name_v, weight_v))
@@ -111,7 +140,7 @@ class WeightBinsWriter(converter_base.ModelWriterBase):
           var_name = var_name.replace('query', 'q')
         if 'value' in var_name:
           var_name = var_name.replace('value', 'v')
-        path = os.path.join(
+        path = _safe_join(
             self._output_dir, removeprefix(var_name, 'mdl_vars.')
         )
         with filemanager(path, 'wb') as f:


### PR DESCRIPTION
### What

Fixes a path-traversal issue in the MediaPipe GenAI safetensors
converter at
`mediapipe/tasks/python/genai/converter/weight_bins_writer.py`.

Tensor names parsed from a `.safetensors` file's JSON header flow into
four `os.path.join(self._output_dir, var_name)` call sites
(lines 96, 100, 103, 114) and are written to disk via
`f.write(output.tobytes())`. No character-class check, no anchoring to
`output_dir`. A tensor named with traversal tokens (`../`), an
absolute path (`/tmp/...`), or embedded path separators causes the
writer to create files outside the declared output directory with the
attacker's tensor bytes.

The call chain is:

1. `safetensors_converter._SafetensorsShardReader.__init__` reads the
   header and runs it through `json.loads`; tensor names become dict
   keys.
2. `GemmaMapper.update_target_name` (the only transformation applied
   to names) performs `.replace()` calls for known Gemma layer names
   and does not touch `/` or `../`.
3. The untouched name reaches the writer sites above.

### How

Added a module-level `_safe_join(output_dir, var_name)` helper that:

1. Rejects any `var_name` not matching `^[A-Za-z0-9._-]+$`.
2. Anchors the resolved path to `realpath(output_dir)` via
   `os.path.commonpath`, rejecting anything that escapes.

Routed all four call sites in `WeightBinsWriter.write_variables()`
through it.

### Test

`mediapipe/tasks/python/genai/converter/tests/weight_bins_writer_path_safety_test.py`
covers:

- Relative traversal rejected (`../escape.bin`)
- Absolute path rejected (`/tmp/escape.bin`)
- Deep traversal rejected (`../../../../../tmp/escape.bin`)
- Embedded separator rejected (`subdir/file.bin`)
- Safe names accepted (`layer0.w`, `emb-table_1.bin`, `alpha-beta`,
  `a.b.c`)

To run:

```bash
python -m pytest mediapipe/tasks/python/genai/converter/tests/\
weight_bins_writer_path_safety_test.py
```