### PR TITLE
Refactor Apple Frameworks build rules

### DIFF
--- a/third_party/apple_frameworks/BUILD
+++ b/third_party/apple_frameworks/BUILD
@@ -1,93 +1,32 @@
-# Build rules to inject Apple Frameworks
-
 package(default_visibility = ["//visibility:public"])
 
-cc_library(
-    name = "CoreGraphics",
-    linkopts = ["-framework CoreGraphics"],
-)
+def apple_framework(name):
+    native.cc_library(
+        name = name,
+        linkopts = ["-framework {}".format(name)],
+    )
 
-cc_library(
-    name = "CoreMedia",
-    linkopts = ["-framework CoreMedia"],
-)
+# ===== Danh sách frameworks =====
+APPLE_FRAMEWORKS = [
+    "CoreGraphics",
+    "CoreMedia",
+    "UIKit",
+    "Accelerate",
+    "CoreVideo",
+    "Metal",
+    "MetalKit",
+    "MetalPerformanceShaders",
+    "AVFoundation",
+    "AVFAudio",
+    "Foundation",
+    "CoreImage",
+    "XCTest",
+    "GLKit",
+    "OpenGLES",
+    "QuartzCore",
+    "CoreAudio",
+    "MediaToolbox",
+]
 
-cc_library(
-    name = "UIKit",
-    linkopts = ["-framework UIKit"],
-)
-
-cc_library(
-    name = "Accelerate",
-    linkopts = ["-framework Accelerate"],
-)
-
-cc_library(
-    name = "CoreVideo",
-    linkopts = ["-framework CoreVideo"],
-)
-
-cc_library(
-    name = "Metal",
-    linkopts = ["-framework Metal"],
-)
-
-cc_library(
-    name = "MetalKit",
-    linkopts = ["-framework MetalKit"],
-)
-
-cc_library(
-    name = "MetalPerformanceShaders",
-    linkopts = ["-framework MetalPerformanceShaders"],
-)
-
-cc_library(
-    name = "AVFoundation",
-    linkopts = ["-framework AVFoundation"],
-)
-
-cc_library(
-    name = "AVFAudio",
-    linkopts = ["-framework AVFAudio"],
-)
-
-cc_library(
-    name = "Foundation",
-    linkopts = ["-framework Foundation"],
-)
-
-cc_library(
-    name = "CoreImage",
-    linkopts = ["-framework CoreImage"],
-)
-
-cc_library(
-    name = "XCTest",
-    linkopts = ["-framework XCTest"],
-)
-
-cc_library(
-    name = "GLKit",
-    linkopts = ["-framework GLKit"],
-)
-
-cc_library(
-    name = "OpenGLES",
-    linkopts = ["-framework OpenGLES"],
-)
-
-cc_library(
-    name = "QuartzCore",
-    linkopts = ["-framework QuartzCore"],
-)
-
-cc_library(
-    name = "CoreAudio",
-    linkopts = ["-framework CoreAudio"],
-)
-
-cc_library(
-    name = "MediaToolbox",
-    linkopts = ["-framework MediaToolbox"],
-)
+# ===== Auto generate rules =====
+[apple_framework(fw) for fw in APPLE_FRAMEWORKS]


### PR DESCRIPTION
Refactored Apple Frameworks build rules to use a function for library creation, simplifying the addition of frameworks.