### PR TITLE
Add native Windows ARM64 (WoA) build support to mediapipe

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,45 @@ build:windows --copt=/w
 build:windows --copt=/D_USE_MATH_DEFINES
 build:windows --host_copt=/D_USE_MATH_DEFINES
 
+# windows arm64
+build:windows_arm64 --config=windows
+build:windows_arm64 --cpu=arm64_windows
+build:windows_arm64 --platforms=@//mediapipe:windows_arm64_platform
+build:windows_arm64 --enable_runfiles
+# Disable GPU for ARM64 build
+build:windows_arm64 --define=MEDIAPIPE_DISABLE_GPU=1
+# MSVC does not support __builtin_expect; disable its use in farmhash.
+build:windows_arm64 --copt=/DFARMHASH_NO_BUILTIN_EXPECT
+# MSVC conformant preprocessor and Windows header macros to reduce
+# namespace pollution and avoid macro conflicts (min/max, GDI, etc.)
+build:windows_arm64 --copt=/Zc:preprocessor
+build:windows_arm64 --host_copt=/Zc:preprocessor
+build:windows_arm64 --copt=/DNOMINMAX
+build:windows_arm64 --host_copt=/DNOMINMAX
+build:windows_arm64 --copt=/DWIN32_LEAN_AND_MEAN
+build:windows_arm64 --host_copt=/DWIN32_LEAN_AND_MEAN
+build:windows_arm64 --copt=/DNOGDI
+# MSVC for ARM64 does not support __fp16 arithmetic
+build:windows_arm64 --define=xnn_enable_arm_fp16_scalar=false
+build:windows_arm64 --define=xnn_enable_arm_fp16_vector=false
+build:windows_arm64 --define=xnn_enable_arm_dotprod=false
+# MSVC for ARM64 does not support inline assembly
+build:windows_arm64 --define=xnn_enable_assembly=false
+# MSVC for ARM64 does not support SVE/SVE2 intrinsics. Disable SME/SME2 kernels.
+build:windows_arm64 --define=xnn_enable_arm_sme=false
+build:windows_arm64 --define=xnn_enable_arm_sme2=false
+# Disable TFLite XNNPACK delegate for Windows ARM64.
+build:windows_arm64 --define=tflite_with_xnnpack=false
+# Windows ARM64: Bazel exec config misses protobuf src include path; add
+# external/com_google_protobuf/src so "google/protobuf/..." headers resolve.
+build:windows_arm64 --host_copt=/Iexternal/com_google_protobuf/src
+build:windows_arm64 --copt=/Iexternal/com_google_protobuf/src
+# Exclude WinUser.h to avoid GDI macro conflicts (Rectangle, DrawText, etc.)
+# that clash with identifiers in these source files.
+build:windows_arm64 --per_file_copt=mediapipe/util/annotation_renderer\.cc@/DNOUSER
+build:windows_arm64 --per_file_copt=mediapipe/framework/tool/proto_util_lite\.cc@/DNOUSER
+build:windows_arm64 --per_file_copt=mediapipe/framework/tool/template_parser\.cc@/DNOUSER
+
 # macOS
 build:macos --cxxopt=-std=c++20
 build:macos --host_cxxopt=-std=c++20

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,68 +25,47 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(minimum_bazel_version = "3.7.2")
 
-# Provides platforms and constraints that the updated C++, Java, and Protobuf rules require to
-# function correctly.
-http_archive(
-    name = "platforms",
-    urls = [
-        "https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
-    ],
-    sha256 = "29742e87275809b5e598dc2f04d86960cc7a55b3067d97221c9abbc9926bff0f",
-)
-
-# ABSL on 2025-01-14
+# ABSL on 2023-10-18
 http_archive(
     name = "com_google_absl",
-    repo_mapping = {"@googletest": "@com_google_googletest"},
-    sha256 = "87e91fb785a2d0233f4599317afd576b7736e6732d557bdcdfdc11990bd333ef",
-    strip_prefix = "abseil-cpp-255c84dadd029fd8ad25c5efb5933e47beaa00c7",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/255c84dadd029fd8ad25c5efb5933e47beaa00c7.tar.gz"],
-)
-
-# RE2 version 2025-11-05 (and later) explicitly adds the missing <cstring> include to prog.h and
-# improves compatibility with newer Abseil versions)
-http_archive(
-    name = "com_googlesource_code_re2",
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
-    sha256 = "87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67",
-    strip_prefix = "re2-2025-11-05",
-    urls = [
-        "https://github.com/google/re2/archive/2025-11-05.tar.gz",
+    patch_args = [
+        "-p1",
     ],
+    patches = [
+        "@//third_party:com_google_absl_windows_patch.diff",
+    ],
+    sha256 = "f841f78243f179326f2a80b719f2887c38fe226d288ecdc46e2aa091e6aa43bc",
+    strip_prefix = "abseil-cpp-9687a8ea750bfcddf790372093245a1d041b21a3",
+    urls = ["https://github.com/abseil/abseil-cpp/archive//9687a8ea750bfcddf790372093245a1d041b21a3.tar.gz"],
 )
 
-# We are migrating to the Starlark-native architectural branch of rules_cc. While the 0.1.x series
-# has a higher version number, it is a legacy branch. The 0.0.17 version (and its successor 0.2.x)
-# is required to support the toolchain resolution requirements of Protobuf 6.x and Abseil 2025.
 http_archive(
     name = "rules_cc",
-    sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
-    strip_prefix = "rules_cc-0.0.17",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"],
+    patch_args = ["-p1"],
+    patches = ["@//third_party:rules_cc.diff"],
+    sha256 = "0d3b4f984c4c2e1acfd1378e0148d35caf2ef1d9eb95b688f8e19ce0c41bdf5b",
+    strip_prefix = "rules_cc-0.1.4",
+    url = "https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz",
 )
-
-load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
-rules_cc_dependencies()
-rules_cc_toolchains()
 
 http_archive(
     name = "rules_java",
-    sha256 = "eb5447f019734b0c4284eaa5f8248415084da5445ba8201c935a211ab8af43a0",
-    url = "https://github.com/bazelbuild/rules_java/releases/download/7.10.0/rules_java-7.10.0.tar.gz",
+    sha256 = "c73336802d0b4882e40770666ad055212df4ea62cfa6edf9cb0f9d29828a0934",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz",
 )
 
 http_archive(
     name = "com_google_protobuf",
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
-    sha256 = "6e09bbc950ba60c3a7b30280210cd285af8d7d8ed5e0a6ed101c72aff22e8d88",
-    strip_prefix = "protobuf-6.31.1",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.31.1.zip"],
+    patch_args = [
+        "-p1",
+    ],
+    patches = [
+        "@//third_party:com_google_protobuf_fixes.diff",
+    ],
+    sha256 = "f645e6e42745ce922ca5388b1883ca583bafe4366cc74cf35c3c9299005136e2",
+    strip_prefix = "protobuf-5.28.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.zip"],
 )
-
-load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility
-
-proto_bazel_features(name = "proto_bazel_features")
 
 http_archive(
     name = "rules_android_ndk",
@@ -139,14 +118,24 @@ http_archive(
 http_archive(
     name = "zlib",
     build_file = "@//third_party:zlib.BUILD",
-    sha256 = "17e88863f3600672ab49182f217281b6fc4d3c762bde361935e436a95214d05c",
-    strip_prefix = "zlib-1.3.1",
-    url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+    patch_args = [
+        "-p1",
+    ],
+    patches = [
+        "@//third_party:zlib.diff",
+    ],
+    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
+    strip_prefix = "zlib-1.2.13",
+    url = "http://zlib.net/fossils/zlib-1.2.13.tar.gz",
 )
 
 # gflags needed by glog
 http_archive(
     name = "com_github_gflags_gflags",
+    patch_args = ["-p1"],
+    patches = [
+        "@//third_party:com_github_gflags_gflags_windows_patch.diff",
+    ],
     sha256 = "19713a36c9f32b33df59d1c79b4958434cb005b5b47dc5400a7a4b078111d9b5",
     strip_prefix = "gflags-2.2.2",
     url = "https://github.com/gflags/gflags/archive/v2.2.2.zip",
@@ -278,6 +267,8 @@ http_archive(
 http_archive(
     name = "XNNPACK",
     # `curl -L <url> | shasum -a 256`
+    patch_args = ["-p1", "-l"],
+    patches = ["@//third_party:xnnpack_windows_arm64.diff"],
     sha256 = "7235b2b55fbf11b64f38db130efae0f293d2d6d6fd90613221b598a8847f41c5",
     strip_prefix = "XNNPACK-68167d1fefa50296f0588ec280f48c58357ca898",
     url = "https://github.com/google/XNNPACK/archive/68167d1fefa50296f0588ec280f48c58357ca898.zip",
@@ -325,6 +316,8 @@ http_archive(
 # 2025-09-08
 http_archive(
     name = "cpuinfo",
+    patch_args = ["-p1"],
+    patches = ["@//third_party:cpuinfo.diff"],
     sha256 = "c0254ce97f7abc778dd2df0aaca1e0506dba1cd514fdb9fe88c07849393f8ef4",
     strip_prefix = "cpuinfo-8a9210069b5a37dd89ed118a783945502a30a4ae",
     urls = [
@@ -336,6 +329,8 @@ http_archive(
 http_archive(
     name = "pthreadpool",
     # `curl -L <url> | shasum -a 256`
+    patch_args = ["-p1"],
+    patches = ["@//third_party:pthreadpool.diff"],
     sha256 = "d5a78b017839ee0474e6aef6e21742b03f641b260f29faf9538a0a6b8fae0704",
     strip_prefix = "pthreadpool-995229919303dd98c0f1b3b585b54527067ef893",
     urls = ["https://github.com/google/pthreadpool/archive/995229919303dd98c0f1b3b585b54527067ef893.zip"],
@@ -361,6 +356,8 @@ http_archive(
         # Works around Bazel issue with objc_library.
         # See https://github.com/bazelbuild/bazel/issues/19912
         "@//third_party:org_tensorflow_objc_build_fixes.diff",
+        # Fix ICU build for Windows ARM64: add /utf-8 flag for arm64_windows CPU.
+        "@//third_party:org_tensorflow_icu_windows_arm64.diff",
     ],
     sha256 = _TENSORFLOW_SHA256,
     strip_prefix = "tensorflow-%s" % _TENSORFLOW_GIT_COMMIT,
@@ -528,10 +525,9 @@ http_archive(
 # ...but the Java download is currently broken, so we use the "source" download.
 http_archive(
     name = "com_google_protobuf_javalite",
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
-    sha256 = "6e09bbc950ba60c3a7b30280210cd285af8d7d8ed5e0a6ed101c72aff22e8d88",
-    strip_prefix = "protobuf-6.31.1",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.31.1.zip"],
+    sha256 = "f645e6e42745ce922ca5388b1883ca583bafe4366cc74cf35c3c9299005136e2",
+    strip_prefix = "protobuf-5.28.3",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.zip"],
 )
 
 load("@//third_party/flatbuffers:workspace.bzl", flatbuffers = "repo")
@@ -552,6 +548,8 @@ http_archive(
 http_archive(
     name = "pffft",
     build_file = "@//third_party:pffft.BUILD",
+    patch_args = ["-p1"],
+    patches = ["@//third_party:pffft.diff"],
     strip_prefix = "jpommier-pffft-7c3b5a7dc510",
     urls = ["https://bitbucket.org/jpommier/pffft/get/7c3b5a7dc510.zip"],
 )
@@ -596,6 +594,15 @@ http_archive(
     strip_prefix = "text-2.2.0",
     urls = [
         "https://github.com/tensorflow/text/archive/v2.2.0.zip",
+    ],
+)
+
+http_archive(
+    name = "com_googlesource_code_re2",
+    sha256 = "ef516fb84824a597c4d5d0d6d330daedb18363b5a99eda87d027e6bdd9cba299",
+    strip_prefix = "re2-03da4fc0857c285e3a26782f6bc8931c4c950df4",
+    urls = [
+        "https://github.com/google/re2/archive/03da4fc0857c285e3a26782f6bc8931c4c950df4.tar.gz",
     ],
 )
 
@@ -650,6 +657,12 @@ new_local_repository(
 new_local_repository(
     name = "windows_opencv",
     build_file = "@//third_party:opencv_windows.BUILD",
+    path = "C:\\opencv\\build",
+)
+
+new_local_repository(
+    name = "windows_opencv_arm64",
+    build_file = "@//third_party:opencv_windows_arm64.BUILD",
     path = "C:\\opencv\\build",
 )
 
@@ -825,13 +838,11 @@ http_archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.2.0.tar.gz"],
 )
 
-# Protobuf Javascript v4.0.2 is compatible with Protobuf v6.31.1
 http_archive(
     name = "com_google_protobuf_javascript",
-    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
-    sha256 = "a08244115ed0535971ec894abf078da90ad2c0938700612f90dc550f218627ee",
-    strip_prefix = "protobuf-javascript-4.0.2",
-    urls = ["https://github.com/protocolbuffers/protobuf-javascript/archive/refs/tags/v4.0.2.tar.gz"],
+    sha256 = "8cef92b4c803429af0c11c4090a76b6a931f82d21e0830760a17f9c6cb358150",
+    strip_prefix = "protobuf-javascript-3.21.4",
+    urls = ["https://github.com/protocolbuffers/protobuf-javascript/archive/refs/tags/v3.21.4.tar.gz"],
 )
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,47 +25,68 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check(minimum_bazel_version = "3.7.2")
 
-# ABSL on 2023-10-18
+# Provides platforms and constraints that the updated C++, Java, and Protobuf rules require to
+# function correctly.
 http_archive(
-    name = "com_google_absl",
-    patch_args = [
-        "-p1",
+    name = "platforms",
+    urls = [
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz",
     ],
-    patches = [
-        "@//third_party:com_google_absl_windows_patch.diff",
-    ],
-    sha256 = "f841f78243f179326f2a80b719f2887c38fe226d288ecdc46e2aa091e6aa43bc",
-    strip_prefix = "abseil-cpp-9687a8ea750bfcddf790372093245a1d041b21a3",
-    urls = ["https://github.com/abseil/abseil-cpp/archive//9687a8ea750bfcddf790372093245a1d041b21a3.tar.gz"],
+    sha256 = "29742e87275809b5e598dc2f04d86960cc7a55b3067d97221c9abbc9926bff0f",
 )
 
+# ABSL on 2025-01-14
+http_archive(
+    name = "com_google_absl",
+    repo_mapping = {"@googletest": "@com_google_googletest"},
+    sha256 = "87e91fb785a2d0233f4599317afd576b7736e6732d557bdcdfdc11990bd333ef",
+    strip_prefix = "abseil-cpp-255c84dadd029fd8ad25c5efb5933e47beaa00c7",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/255c84dadd029fd8ad25c5efb5933e47beaa00c7.tar.gz"],
+)
+
+# RE2 version 2025-11-05 (and later) explicitly adds the missing <cstring> include to prog.h and
+# improves compatibility with newer Abseil versions)
+http_archive(
+    name = "com_googlesource_code_re2",
+    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
+    sha256 = "87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67",
+    strip_prefix = "re2-2025-11-05",
+    urls = [
+        "https://github.com/google/re2/archive/2025-11-05.tar.gz",
+    ],
+)
+
+# We are migrating to the Starlark-native architectural branch of rules_cc. While the 0.1.x series
+# has a higher version number, it is a legacy branch. The 0.0.17 version (and its successor 0.2.x)
+# is required to support the toolchain resolution requirements of Protobuf 6.x and Abseil 2025.
 http_archive(
     name = "rules_cc",
-    patch_args = ["-p1"],
-    patches = ["@//third_party:rules_cc.diff"],
-    sha256 = "0d3b4f984c4c2e1acfd1378e0148d35caf2ef1d9eb95b688f8e19ce0c41bdf5b",
-    strip_prefix = "rules_cc-0.1.4",
-    url = "https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz",
+    sha256 = "abc605dd850f813bb37004b77db20106a19311a96b2da1c92b789da529d28fe1",
+    strip_prefix = "rules_cc-0.0.17",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.17/rules_cc-0.0.17.tar.gz"],
 )
+
+load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies", "rules_cc_toolchains")
+rules_cc_dependencies()
+rules_cc_toolchains()
 
 http_archive(
     name = "rules_java",
-    sha256 = "c73336802d0b4882e40770666ad055212df4ea62cfa6edf9cb0f9d29828a0934",
-    url = "https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz",
+    sha256 = "eb5447f019734b0c4284eaa5f8248415084da5445ba8201c935a211ab8af43a0",
+    url = "https://github.com/bazelbuild/rules_java/releases/download/7.10.0/rules_java-7.10.0.tar.gz",
 )
 
 http_archive(
     name = "com_google_protobuf",
-    patch_args = [
-        "-p1",
-    ],
-    patches = [
-        "@//third_party:com_google_protobuf_fixes.diff",
-    ],
-    sha256 = "f645e6e42745ce922ca5388b1883ca583bafe4366cc74cf35c3c9299005136e2",
-    strip_prefix = "protobuf-5.28.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.zip"],
+    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
+    sha256 = "6e09bbc950ba60c3a7b30280210cd285af8d7d8ed5e0a6ed101c72aff22e8d88",
+    strip_prefix = "protobuf-6.31.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.31.1.zip"],
 )
+
+load("@com_google_protobuf//bazel/private:proto_bazel_features.bzl", "proto_bazel_features")  # buildifier: disable=bzl-visibility
+
+proto_bazel_features(name = "proto_bazel_features")
 
 http_archive(
     name = "rules_android_ndk",
@@ -118,15 +139,9 @@ http_archive(
 http_archive(
     name = "zlib",
     build_file = "@//third_party:zlib.BUILD",
-    patch_args = [
-        "-p1",
-    ],
-    patches = [
-        "@//third_party:zlib.diff",
-    ],
-    sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
-    strip_prefix = "zlib-1.2.13",
-    url = "http://zlib.net/fossils/zlib-1.2.13.tar.gz",
+    sha256 = "17e88863f3600672ab49182f217281b6fc4d3c762bde361935e436a95214d05c",
+    strip_prefix = "zlib-1.3.1",
+    url = "https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
 )
 
 # gflags needed by glog
@@ -525,9 +540,10 @@ http_archive(
 # ...but the Java download is currently broken, so we use the "source" download.
 http_archive(
     name = "com_google_protobuf_javalite",
-    sha256 = "f645e6e42745ce922ca5388b1883ca583bafe4366cc74cf35c3c9299005136e2",
-    strip_prefix = "protobuf-5.28.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v5.28.3.zip"],
+    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
+    sha256 = "6e09bbc950ba60c3a7b30280210cd285af8d7d8ed5e0a6ed101c72aff22e8d88",
+    strip_prefix = "protobuf-6.31.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v6.31.1.zip"],
 )
 
 load("@//third_party/flatbuffers:workspace.bzl", flatbuffers = "repo")
@@ -594,15 +610,6 @@ http_archive(
     strip_prefix = "text-2.2.0",
     urls = [
         "https://github.com/tensorflow/text/archive/v2.2.0.zip",
-    ],
-)
-
-http_archive(
-    name = "com_googlesource_code_re2",
-    sha256 = "ef516fb84824a597c4d5d0d6d330daedb18363b5a99eda87d027e6bdd9cba299",
-    strip_prefix = "re2-03da4fc0857c285e3a26782f6bc8931c4c950df4",
-    urls = [
-        "https://github.com/google/re2/archive/03da4fc0857c285e3a26782f6bc8931c4c950df4.tar.gz",
     ],
 )
 
@@ -838,11 +845,13 @@ http_archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.2.0.tar.gz"],
 )
 
+# Protobuf Javascript v4.0.2 is compatible with Protobuf v6.31.1
 http_archive(
     name = "com_google_protobuf_javascript",
-    sha256 = "8cef92b4c803429af0c11c4090a76b6a931f82d21e0830760a17f9c6cb358150",
-    strip_prefix = "protobuf-javascript-3.21.4",
-    urls = ["https://github.com/protocolbuffers/protobuf-javascript/archive/refs/tags/v3.21.4.tar.gz"],
+    repo_mapping = {"@abseil-cpp": "@com_google_absl"},
+    sha256 = "a08244115ed0535971ec894abf078da90ad2c0938700612f90dc550f218627ee",
+    strip_prefix = "protobuf-javascript-4.0.2",
+    urls = ["https://github.com/protocolbuffers/protobuf-javascript/archive/refs/tags/v4.0.2.tar.gz"],
 )
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")

--- a/mediapipe/BUILD
+++ b/mediapipe/BUILD
@@ -186,6 +186,16 @@ config_setting_and_platform(
     visibility = ["//visibility:public"],
 )
 
+# Windows ARM64.
+config_setting_and_platform(
+    name = "windows_arm64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:arm64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 # Linux 64-bit.
 config_setting_and_platform(
     name = "linux",

--- a/mediapipe/framework/BUILD
+++ b/mediapipe/framework/BUILD
@@ -1813,9 +1813,11 @@ cc_test(
     name = "packet_delete_test",
     size = "small",
     srcs = ["packet_delete_test.cc"],
-    copts = [
-        "-Werror",
-    ],
+    # MSVC doesn't support -Werror
+    copts = select({
+        "@bazel_tools//src/conditions:windows": ["/WX"],
+        "//conditions:default": ["-Werror"],
+    }),
     linkstatic = 1,
     deps = [
         ":packet",

--- a/mediapipe/framework/api3/calculator_context.h
+++ b/mediapipe/framework/api3/calculator_context.h
@@ -431,8 +431,8 @@ auto VisitPacketOrDie(F&& visitor, const mediapipe::Packet& packet) {
   return std::forward<F>(visitor)(packet.Get<T>());
 }
 
-template <typename T, typename U, typename... Rest, int&... DoNotSpecify,
-          typename F>
+//DoNotSpecify argument removed since it is not being referenced in the function definition nor in any call site
+template <typename T, typename U, typename... Rest, typename F>
 auto VisitPacketOrDie(F&& visitor, const mediapipe::Packet& packet) {
   if (packet.ValidateAsType<T>().ok()) {
     return std::forward<F>(visitor)(packet.Get<T>());
@@ -447,8 +447,8 @@ auto VisitPacketAsPacketOrDie(F&& visitor, const mediapipe::Packet& packet) {
   return std::forward<F>(visitor)(WrapLegacyPacket<T>(packet).value());
 }
 
-template <typename T, typename U, typename... Rest, int&... DoNotSpecify,
-          typename F>
+//DoNotSpecify argument removed since it is not being referenced in the function definition nor in any call site
+template <typename T, typename U, typename... Rest, typename F>
 auto VisitPacketAsPacketOrDie(F&& visitor, const mediapipe::Packet& packet) {
   if (packet.ValidateAsType<T>().ok()) {
     return std::forward<F>(visitor)(WrapLegacyPacket<T>(packet).value());

--- a/mediapipe/framework/api3/graph.h
+++ b/mediapipe/framework/api3/graph.h
@@ -107,6 +107,12 @@ class Graph;
 class GenericGraph;
 class FunctionGraphBuilder;
 
+// Forward declaration needed for MSVC to correctly resolve the template friend
+// declaration inside GenericGraph (avoids conflict with non-template
+// mediapipe::SubgraphContext from subgraph.h).
+template <typename NodeT>
+class SubgraphContext;
+
 // `GraphNode` is returned by `Graph<...>::AddNode<...>()` function.
 //
 // Common pattern to use it:

--- a/mediapipe/framework/calculator_graph_test.cc
+++ b/mediapipe/framework/calculator_graph_test.cc
@@ -14,7 +14,10 @@
 
 #include "mediapipe/framework/calculator_graph.h"
 
+// pthread.h is not available on Windows
+#ifndef _WIN32
 #include <pthread.h>
+#endif
 
 #include <atomic>
 #include <cstdint>
@@ -975,6 +978,8 @@ class OneShot20MsCalculator : public CalculatorBase {
 };
 REGISTER_CALCULATOR(OneShot20MsCalculator);
 
+// Excluded on Windows: pthread_self() and pthread_t are not available.
+#ifndef _WIN32
 // A source calculator that outputs a packet containing the return value of
 // pthread_self() (the pthread id of the current thread).
 class PthreadSelfSourceCalculator : public CalculatorBase {
@@ -991,6 +996,7 @@ class PthreadSelfSourceCalculator : public CalculatorBase {
   }
 };
 REGISTER_CALCULATOR(PthreadSelfSourceCalculator);
+#endif
 
 // A source calculator for testing the Calculator::InputTimestamp() method.
 // It outputs five int packets with timestamps 0, 1, 2, 3, 4.
@@ -4364,6 +4370,8 @@ TEST(CalculatorGraph, NumThreadsAndNonDefaultExecutorConfig) {
 // "ApplicationThreadExecutor" is specified.  In this test
 // "ApplicationThreadExecutor" is specified in the ExecutorConfig for the
 // default executor.
+// Excluded on Windows: this test uses PthreadSelfSourceCalculator which is unavailable on Windows.
+#ifndef _WIN32
 TEST(CalculatorGraph, RunWithNumThreadsInExecutorConfig) {
   const struct {
     std::string executor_type;
@@ -4405,6 +4413,7 @@ TEST(CalculatorGraph, RunWithNumThreadsInExecutorConfig) {
         << "for case " << i;
   }
 }
+#endif
 
 TEST(CalculatorGraph, CalculatorGraphNotInitialized) {
   CalculatorGraph graph;

--- a/mediapipe/framework/calculator_node_test.cc
+++ b/mediapipe/framework/calculator_node_test.cc
@@ -14,7 +14,12 @@
 
 #include "mediapipe/framework/calculator_node.h"
 
+//POSIX unistd.h is not available on Windows.
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 #include <memory>
 
@@ -50,7 +55,12 @@ class CountCalculator : public CalculatorBase {
     ++num_open_;
     // Simulate doing nontrivial work to ensure that the time spent in the
     // method will register on streamz each time it is called.
-    usleep(100);
+    // Windows has no usleep(); use Sleep(1ms) as equivalent delay.
+    #ifdef _WIN32
+      Sleep(1);
+    #else
+      usleep(100);
+    #endif
     return absl::OkStatus();
   }
 
@@ -65,15 +75,25 @@ class CountCalculator : public CalculatorBase {
                        .At(cc->InputTimestamp()));
     // Simulate doing nontrivial work to ensure that the time spent in the
     // method will register on streamz each time it is called.
-    usleep(100);
-    return absl::OkStatus();
+    // Windows has no usleep(); use Sleep(1ms) as equivalent delay.
+    #ifdef _WIN32
+      Sleep(1);
+    #else
+      usleep(100);
+    #endif
+      return absl::OkStatus();
   }
 
   absl::Status Close(CalculatorContext* cc) override {
     ++num_close_;
     // Simulate doing nontrivial work to ensure that the time spent in the
     // method will register on streamz each time it is called.
-    usleep(100);
+    // Windows has no usleep(); use Sleep(1ms) as equivalent delay.
+    #ifdef _WIN32
+      Sleep(1);
+    #else
+      usleep(100);
+    #endif
     return absl::OkStatus();
   }
 

--- a/mediapipe/framework/deps/BUILD
+++ b/mediapipe/framework/deps/BUILD
@@ -181,6 +181,22 @@ cc_library(
 )
 
 cc_library(
+    name = "endian",
+    hdrs = ["endian.h"],
+    deps = ["@com_google_absl//absl/base:config"],
+)
+
+cc_test(
+    name = "endian_test",
+    srcs = ["endian_test.cc"],
+    deps = [
+        ":endian",
+        "//mediapipe/framework/port:gtest_main",
+        "@com_google_absl//absl/base:config",
+    ],
+)
+
+cc_library(
     name = "image_resizer",
     hdrs = ["image_resizer.h"],
     deps = [

--- a/mediapipe/framework/deps/BUILD
+++ b/mediapipe/framework/deps/BUILD
@@ -146,6 +146,7 @@ cc_library(
         "@com_google_absl//absl/strings",
     ] + select({
         "//mediapipe:windows": [],
+        "//mediapipe:windows_arm64": [],
         "//conditions:default": ["//mediapipe/framework/formats:unique_fd"],
     }),
 )
@@ -176,22 +177,6 @@ cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log:absl_check",
         "@com_google_absl//absl/log:absl_log",
-    ],
-)
-
-cc_library(
-    name = "endian",
-    hdrs = ["endian.h"],
-    deps = ["@com_google_absl//absl/base:config"],
-)
-
-cc_test(
-    name = "endian_test",
-    srcs = ["endian_test.cc"],
-    deps = [
-        ":endian",
-        "//mediapipe/framework/port:gtest_main",
-        "@com_google_absl//absl/base:config",
     ],
 )
 
@@ -407,6 +392,7 @@ cc_library(
     name = "threadpool",
     srcs = select({
         "//mediapipe:windows": ["threadpool_std_thread_impl.cc"],
+        "//mediapipe:windows_arm64": ["threadpool_std_thread_impl.cc"],
         "//conditions:default": ["threadpool_pthread_impl.cc"],
     }),
     hdrs = ["threadpool.h"],

--- a/mediapipe/framework/graph_service_test.cc
+++ b/mediapipe/framework/graph_service_test.cc
@@ -309,7 +309,7 @@ TEST(ServiceBindingTest, CrashesWhenGettingNullServiceObject) {
         ServiceBinding<TestServiceData> binding(nullptr);
         (void)binding.GetObject();
       },
-      testing::ContainsRegex("Check failed: [a-z_]* Service is unavailable"));
+      "Check failed: service_ Service is unavailable.");
 }
 
 TEST(ServiceBindingTest, IsAvailableReturnsFalsOnNullServiceObject) {

--- a/mediapipe/framework/legacy_calculator_support.h
+++ b/mediapipe/framework/legacy_calculator_support.h
@@ -59,7 +59,7 @@ class LegacyCalculatorSupport {
     //
     // ABSL_CONST_INIT triggers b/155992786 with some versions of Clang on Apple
     // platforms.
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_MSC_VER)
     ABSL_CONST_INIT
 #endif                                // !__APPLE__
     static thread_local C* current_;  // NOLINT

--- a/mediapipe/framework/nested_calculator_graph_test.cc
+++ b/mediapipe/framework/nested_calculator_graph_test.cc
@@ -27,6 +27,7 @@ namespace api2 {
 namespace {
 
 using ::mediapipe::MakePacket;
+using ::mediapipe::Packet;
 using ::mediapipe::Tensor;
 using ::mediapipe::api2::builder::Stream;
 using ::testing::HasSubstr;
@@ -54,7 +55,7 @@ absl::StatusOr<Tensor> Create1x3IntTensor(std::vector<int> values) {
 class NestedGraphCalculator : public Node {
  public:
   static constexpr Input<Tensor>::Multiple kInput{"TENSORS"};
-  static constexpr Output<::mediapipe::Packet>::Multiple kOutput{"TENSORS"};
+  static constexpr Output<Packet>::Multiple kOutput{"TENSORS"};
   MEDIAPIPE_NODE_CONTRACT(kInput, kOutput);
 
   absl::Status Process(CalculatorContext* cc) override {
@@ -85,11 +86,11 @@ class NestedGraphCalculator : public Node {
             )pb",
             {{"$model", kInt32ModelFile}}));
 
-    std::vector<::mediapipe::Packet> output_packets;
+    std::vector<Packet> output_packets;
     tool::AddVectorSink("output", &graph_config, &output_packets);
 
     MP_EXPECT_OK(graph.Initialize(graph_config));
-    std::map<std::string, ::mediapipe::Packet> side_packets;
+    std::map<std::string, Packet> side_packets;
     MP_EXPECT_OK(graph.StartRun(side_packets));
     MP_EXPECT_OK(graph.AddPacketToInputStream("input", input_tensor));
     MP_EXPECT_OK(graph.CloseAllInputStreams());
@@ -115,7 +116,7 @@ TEST(NestedCalculatorGraphTest, ExecutedNestedGraphWithInferenceCalculator) {
   CalculatorGraph graph;
 
   // Start graph and configure a sink.
-  std::vector<::mediapipe::Packet> result_packets;
+  std::vector<Packet> result_packets;
   tool::AddVectorSink("output", &graph_config, &result_packets);
 
   MP_ASSERT_OK(graph.Initialize(graph_config));
@@ -129,7 +130,7 @@ TEST(NestedCalculatorGraphTest, ExecutedNestedGraphWithInferenceCalculator) {
   MP_ASSERT_OK(graph.CloseAllInputStreams());
   MP_ASSERT_OK(graph.WaitUntilDone());
   EXPECT_EQ(result_packets.size(), 1);
-  const Tensor& result_tensor = result_packets[0].Get<::mediapipe::Packet>().Get<Tensor>();
+  const Tensor& result_tensor = result_packets[0].Get<Packet>().Get<Tensor>();
   EXPECT_EQ(result_tensor.shape().num_elements(), 3);
   {
     const auto view = result_tensor.GetCpuReadView();
@@ -231,7 +232,7 @@ TEST(NestedCalculatorGraphTest, TestNestedGraphServiceInheriting) {
   constexpr int kTestValue = 123;
   MP_EXPECT_OK(
       graph.SetServiceObject(kTestService, std::make_shared<int>(kTestValue)));
-  std::vector<::mediapipe::Packet> result_status;
+  std::vector<Packet> result_status;
   tool::AddVectorSink("startup_error", &graph_config, &result_status);
   MP_ASSERT_OK(graph.Initialize(graph_config));
 
@@ -256,7 +257,7 @@ TEST(NestedCalculatorGraphTest, NestedGraphsCannotRegisterNewServices) {
           output_stream: "STARTUP_ERROR:startup_error"
         })pb");
   CalculatorGraph graph;
-  std::vector<::mediapipe::Packet> result_status;
+  std::vector<Packet> result_status;
   tool::AddVectorSink("startup_error", &graph_config, &result_status);
   MP_ASSERT_OK(graph.Initialize(graph_config));
   MP_ASSERT_OK(graph.StartRun({}));

--- a/mediapipe/framework/nested_calculator_graph_test.cc
+++ b/mediapipe/framework/nested_calculator_graph_test.cc
@@ -27,7 +27,6 @@ namespace api2 {
 namespace {
 
 using ::mediapipe::MakePacket;
-using ::mediapipe::Packet;
 using ::mediapipe::Tensor;
 using ::mediapipe::api2::builder::Stream;
 using ::testing::HasSubstr;
@@ -55,7 +54,7 @@ absl::StatusOr<Tensor> Create1x3IntTensor(std::vector<int> values) {
 class NestedGraphCalculator : public Node {
  public:
   static constexpr Input<Tensor>::Multiple kInput{"TENSORS"};
-  static constexpr Output<Packet>::Multiple kOutput{"TENSORS"};
+  static constexpr Output<::mediapipe::Packet>::Multiple kOutput{"TENSORS"};
   MEDIAPIPE_NODE_CONTRACT(kInput, kOutput);
 
   absl::Status Process(CalculatorContext* cc) override {
@@ -86,11 +85,11 @@ class NestedGraphCalculator : public Node {
             )pb",
             {{"$model", kInt32ModelFile}}));
 
-    std::vector<Packet> output_packets;
+    std::vector<::mediapipe::Packet> output_packets;
     tool::AddVectorSink("output", &graph_config, &output_packets);
 
     MP_EXPECT_OK(graph.Initialize(graph_config));
-    std::map<std::string, Packet> side_packets;
+    std::map<std::string, ::mediapipe::Packet> side_packets;
     MP_EXPECT_OK(graph.StartRun(side_packets));
     MP_EXPECT_OK(graph.AddPacketToInputStream("input", input_tensor));
     MP_EXPECT_OK(graph.CloseAllInputStreams());
@@ -116,7 +115,7 @@ TEST(NestedCalculatorGraphTest, ExecutedNestedGraphWithInferenceCalculator) {
   CalculatorGraph graph;
 
   // Start graph and configure a sink.
-  std::vector<Packet> result_packets;
+  std::vector<::mediapipe::Packet> result_packets;
   tool::AddVectorSink("output", &graph_config, &result_packets);
 
   MP_ASSERT_OK(graph.Initialize(graph_config));
@@ -130,7 +129,7 @@ TEST(NestedCalculatorGraphTest, ExecutedNestedGraphWithInferenceCalculator) {
   MP_ASSERT_OK(graph.CloseAllInputStreams());
   MP_ASSERT_OK(graph.WaitUntilDone());
   EXPECT_EQ(result_packets.size(), 1);
-  const Tensor& result_tensor = result_packets[0].Get<Packet>().Get<Tensor>();
+  const Tensor& result_tensor = result_packets[0].Get<::mediapipe::Packet>().Get<Tensor>();
   EXPECT_EQ(result_tensor.shape().num_elements(), 3);
   {
     const auto view = result_tensor.GetCpuReadView();
@@ -232,7 +231,7 @@ TEST(NestedCalculatorGraphTest, TestNestedGraphServiceInheriting) {
   constexpr int kTestValue = 123;
   MP_EXPECT_OK(
       graph.SetServiceObject(kTestService, std::make_shared<int>(kTestValue)));
-  std::vector<Packet> result_status;
+  std::vector<::mediapipe::Packet> result_status;
   tool::AddVectorSink("startup_error", &graph_config, &result_status);
   MP_ASSERT_OK(graph.Initialize(graph_config));
 
@@ -257,7 +256,7 @@ TEST(NestedCalculatorGraphTest, NestedGraphsCannotRegisterNewServices) {
           output_stream: "STARTUP_ERROR:startup_error"
         })pb");
   CalculatorGraph graph;
-  std::vector<Packet> result_status;
+  std::vector<::mediapipe::Packet> result_status;
   tool::AddVectorSink("startup_error", &graph_config, &result_status);
   MP_ASSERT_OK(graph.Initialize(graph_config));
   MP_ASSERT_OK(graph.StartRun({}));

--- a/mediapipe/framework/packet_test.cc
+++ b/mediapipe/framework/packet_test.cc
@@ -173,7 +173,7 @@ TEST(PacketTest, TypeRegistrationDebugString) {
     expected_type_name = "<unknown>";
   } else {
         #if defined(_MSC_VER)
-          expected_type_name = "struct mediapipe::`anonymous namespace'::UnregisteredPairStruct";
+          expected_type_name = "struct mediapipe::'anonymous namespace'::UnregisteredPairStruct";
         #else
           expected_type_name = "mediapipe::(anonymous namespace)::UnregisteredPairStruct";
         #endif

--- a/mediapipe/framework/packet_test.cc
+++ b/mediapipe/framework/packet_test.cc
@@ -168,10 +168,16 @@ TEST(PacketTest, TypeRegistrationDebugString) {
   // Unregistered type.
   UnregisteredPairStruct u{"s", true};
   Packet packet2 = MakePacket<UnregisteredPairStruct>(u);
-  std::string expected_type_name =
-      (kHaveUnregisteredTypeNames)
-          ? "mediapipe::(anonymous namespace)::UnregisteredPairStruct"
-          : "<unknown>";
+  std::string expected_type_name;
+  if (!kHaveUnregisteredTypeNames) {
+    expected_type_name = "<unknown>";
+  } else {
+        #if defined(_MSC_VER)
+          expected_type_name = "struct mediapipe::`anonymous namespace'::UnregisteredPairStruct";
+        #else
+          expected_type_name = "mediapipe::(anonymous namespace)::UnregisteredPairStruct";
+        #endif
+  }
   EXPECT_EQ(packet2.DebugString(),
             "mediapipe::Packet with timestamp: Timestamp::Unset() and type: " +
                 expected_type_name);
@@ -248,6 +254,10 @@ TEST(PacketTest, SyncedPacket) {
   EXPECT_EQ(999, packet_new.Get<int>());
 }
 
+// Excluded on Windows: MSVC cannot resolve operator new[] for array types in templates.
+#ifndef _WIN32
+// Array packet tests are disabled on Windows because MSVC has a known
+// limitation with operator new[] ambiguity for array types in templates.
 TEST(PacketTest, MakePacketOfIntArray) {
   Packet int_packet = MakePacket<int>(123);
   EXPECT_EQ(123, int_packet.Get<int>());
@@ -258,6 +268,7 @@ TEST(PacketTest, MakePacketOfIntArray) {
   EXPECT_EQ(64, array_ref[1]);
   EXPECT_EQ(128, array_ref[2]);
 }
+#endif
 
 TEST(PacketTest, MakePacketOfIntVector) {
   std::vector<int> vector({1, 2, 3});
@@ -436,6 +447,10 @@ TEST(PacketTest, TestForeignHolderConsumeOrCopy) {
   EXPECT_EQ(33, *result2.value());
 }
 
+// Excluded on Windows: MSVC cannot resolve operator new[] for array types in templates.
+#ifndef _WIN32
+// Array packet tests are disabled on Windows because MSVC has a known
+// limitation with operator new[] ambiguity for array types in templates.
 TEST(PacketTest, TestConsumeBoundedArray) {
   Packet packet1 = MakePacket<int[3]>(10, 20, 30);
   Packet packet_copy = packet1;
@@ -506,6 +521,7 @@ TEST(PacketTest, TestConsumeOrCopyBoundedArray) {
   EXPECT_EQ(60, (*value3)[2]);
   EXPECT_TRUE(packet2.IsEmpty());
 }
+#endif
 
 TEST(PacketTest, MessageHolderRegistration) {
   using testing::Contains;

--- a/mediapipe/gpu/gpu_service.cc
+++ b/mediapipe/gpu/gpu_service.cc
@@ -16,7 +16,7 @@
 
 namespace mediapipe {
 
-const GraphService<GpuResources> kGpuService(
+ABSL_CONST_INIT const GraphService<GpuResources> kGpuService(
     "kGpuService", GraphServiceBase::kAllowDefaultInitialization);
 
 }  // namespace mediapipe

--- a/platform_mappings
+++ b/platform_mappings
@@ -57,5 +57,8 @@ flags:
   --cpu=x64_windows
     @mediapipe//mediapipe:windows_platform
 
+  --cpu=arm64_windows
+    @mediapipe//mediapipe:windows_arm64_platform
+
   --cpu=k8
     @mediapipe//mediapipe:linux_platform

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,18 @@ import shutil
 import subprocess
 import sys
 
+VERSION = {}
+exec(open('mediapipe/version.bzl').read(), VERSION)
+
 import setuptools
 from setuptools.command import build_ext
 from setuptools.command import build_py
 from setuptools.command import install
 
-__version__ = 'dev'
+__version__ = VERSION['MEDIAPIPE_FULL_VERSION']
 MP_DISABLE_GPU = os.environ.get('MEDIAPIPE_DISABLE_GPU') != '0'
 IS_WINDOWS = (platform.system() == 'Windows')
+IS_WINDOWS_ARM64 = IS_WINDOWS and (platform.machine().lower() in ['arm64'])
 IS_MAC = (platform.system() == 'Darwin')
 MP_ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
 MP_DIR_INIT_PY = os.path.join(MP_ROOT_PATH, 'mediapipe/__init__.py')
@@ -138,7 +142,7 @@ def _add_mp_init_files():
   mp_dir_init_file = open(MP_DIR_INIT_PY, 'a')
   mp_dir_init_file.writelines([
       '\n',
-      'import mediapipe.tasks.python as tasks\n',
+      'from mediapipe.tasks import python as tasks\n',
       'from mediapipe.tasks.python.vision.core.image import Image\n',
       'from mediapipe.tasks.python.vision.core.image import ImageFormat\n',
       '\n\n',
@@ -183,6 +187,12 @@ class GenerateMetadataSchema(build_ext.build_ext):
           '--action_env=PYTHON_BIN_PATH=' + _normalize_path(sys.executable),
           '//mediapipe/tasks/metadata:' + target,
       ] + GPU_OPTIONS
+
+      # Activate the windows_arm64 Bazel config when building natively on
+      # Windows ARM64.  This config (defined in .bazelrc) applies all the
+      # ARM64-specific workarounds needed for Windows ARM6
+      if IS_WINDOWS_ARM64:
+        bazel_command.append('--config=windows_arm64')
 
       _invoke_shell_command(bazel_command)
       _copy_to_build_lib_dir(
@@ -244,9 +254,19 @@ class BuildExtension(build_ext.build_ext):
         '--compilation_mode=opt',
         '--copt=-DNDEBUG',
         '--keep_going',
-        '--define=ENABLE_ODML_CONVERTER=1',
         str(ext.bazel_target),
     ] + GPU_OPTIONS
+
+    # Activate the windows_arm64 Bazel config when building natively on
+    # Windows ARM64.  This config (defined in .bazelrc) applies all the
+    # ARM64-specific workarounds needed for Windows ARM6
+    if IS_WINDOWS_ARM64:
+      bazel_command.append('--config=windows_arm64')
+
+    # Only enable ODML converter on non-Windows ARM64 platforms
+    # ODML dependencies are not available for Windows ARM64 builds
+    if not IS_WINDOWS_ARM64:
+      bazel_command.append('--define=ENABLE_ODML_CONVERTER=1')
 
     if extra_args:
       bazel_command += extra_args

--- a/setup.py
+++ b/setup.py
@@ -188,9 +188,7 @@ class GenerateMetadataSchema(build_ext.build_ext):
           '//mediapipe/tasks/metadata:' + target,
       ] + GPU_OPTIONS
 
-      # Activate the windows_arm64 Bazel config when building natively on
-      # Windows ARM64.  This config (defined in .bazelrc) applies all the
-      # ARM64-specific workarounds needed for Windows ARM6
+      # Activate the windows_arm64 Bazel config when building natively on Windows ARM64.
       if IS_WINDOWS_ARM64:
         bazel_command.append('--config=windows_arm64')
 
@@ -257,9 +255,7 @@ class BuildExtension(build_ext.build_ext):
         str(ext.bazel_target),
     ] + GPU_OPTIONS
 
-    # Activate the windows_arm64 Bazel config when building natively on
-    # Windows ARM64.  This config (defined in .bazelrc) applies all the
-    # ARM64-specific workarounds needed for Windows ARM6
+    # Activate the windows_arm64 Bazel config when building natively on Windows ARM64.
     if IS_WINDOWS_ARM64:
       bazel_command.append('--config=windows_arm64')
 

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -306,6 +306,7 @@ alias(
         "//mediapipe:ios": "@ios_opencv//:opencv",
         "//mediapipe:macos": "@macos_opencv//:opencv",
         "//mediapipe:windows": "@windows_opencv//:opencv",
+        "//mediapipe:windows_arm64": "@windows_opencv_arm64//:opencv",
         "//conditions:default": "@linux_opencv//:opencv",
     }),
 )

--- a/third_party/com_github_gflags_gflags_windows_patch.diff
+++ b/third_party/com_github_gflags_gflags_windows_patch.diff
@@ -1,0 +1,62 @@
+diff --git a/BUILD b/BUILD
+--- a/BUILD
++++ b/BUILD
+@@ -9,6 +9,11 @@
+ config_setting(
+     name = "x64_windows",
+     values = {"cpu": "x64_windows"},
+ )
+ 
++config_setting(
++    name = "arm64_windows",
++    values = {"cpu": "arm64_windows"},
++)
++
+ load(":bazel/gflags.bzl", "gflags_sources", "gflags_library")
+ 
+ (hdrs, srcs) = gflags_sources(namespace=["gflags", "google"])
+diff --git a/bazel/gflags.bzl b/bazel/gflags.bzl
+--- a/bazel/gflags.bzl
++++ b/bazel/gflags.bzl
+@@ -51,8 +51,12 @@
+     ] + select({
+         "//:x64_windows": [
+             "src/windows_port.cc",
+             "src/windows_port.h",
+         ],
++        "//:arm64_windows": [
++            "src/windows_port.cc",
++            "src/windows_port.h",
++        ],
+         "//conditions:default": [],
+     })
+     return [hdrs, srcs]
+@@ -76,7 +80,10 @@
+     ] + select({
+         "//:x64_windows": [
+             "-DOS_WINDOWS",
+         ],
++        "//:arm64_windows": [
++            "-DOS_WINDOWS",
++        ],
+         "//conditions:default": [
+             "-DHAVE_UNISTD_H",
+             "-DHAVE_FNMATCH_H",
+@@ -88,4 +95,5 @@
+         linkopts += select({
+             "//:x64_windows": [],
++            "//:arm64_windows": [],
+             "//conditions:default": ["-lpthread"],
+         })
+diff --git a/src/util.h b/src/util.h
+--- a/src/util.h
++++ b/src/util.h
+@@ -245,7 +245,8 @@
+   mkdir(path->c_str());
+ }
+ #elif defined(_MSC_VER)
+ #include <direct.h>
++#include <windows.h>
+ inline void MakeTmpdir(std::string* path) {
+   if (!path->empty()) {
+ 	int err = _mkdir(path->c_str());

--- a/third_party/cpuinfo.diff
+++ b/third_party/cpuinfo.diff
@@ -1,0 +1,19 @@
+--- a/src/arm/cache.c
++++ b/src/arm/cache.c
+@@ -9,11 +9,11 @@
+ void cpuinfo_arm_decode_cache(
+ 	enum cpuinfo_uarch uarch,
+ 	uint32_t cluster_cores,
+ 	uint32_t midr,
+-	const struct cpuinfo_arm_chipset chipset[restrict static 1],
++	const struct cpuinfo_arm_chipset chipset[RESTRICT_STATIC 1],
+ 	uint32_t cluster_id,
+ 	uint32_t arch_version,
+-	struct cpuinfo_cache l1i[restrict static 1],
+-	struct cpuinfo_cache l1d[restrict static 1],
+-	struct cpuinfo_cache l2[restrict static 1],
+-	struct cpuinfo_cache l3[restrict static 1]) {
++	struct cpuinfo_cache l1i[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l1d[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l2[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l3[RESTRICT_STATIC 1]) {

--- a/third_party/opencv_windows_arm64.BUILD
+++ b/third_party/opencv_windows_arm64.BUILD
@@ -1,0 +1,38 @@
+# Description:
+#   OpenCV libraries for video/image processing on Windows ARM64
+
+licenses(["notice"])  # BSD license
+
+exports_files(["LICENSE"])
+
+OPENCV_VERSION = "3410"  # 3.4.10
+
+config_setting(
+    name = "opt_build",
+    values = {"compilation_mode": "opt"},
+)
+
+config_setting(
+    name = "dbg_build",
+    values = {"compilation_mode": "dbg"},
+)
+
+# OpenCV ARM64 build configuration for Windows 
+# Uses the prebuilt OpenCV libraries from C:\opencv\install
+cc_library(
+    name = "opencv",
+    srcs = select({
+        ":opt_build": [
+            "ARM64/vc17/lib/opencv_world" + OPENCV_VERSION + ".lib",
+            "ARM64/vc17/bin/opencv_world" + OPENCV_VERSION + ".dll",
+        ],
+        ":dbg_build": [
+            "ARM64/vc17/lib/opencv_world" + OPENCV_VERSION + "d.lib",
+            "ARM64/vc17/bin/opencv_world" + OPENCV_VERSION + "d.dll",
+        ],
+    }),
+    hdrs = glob(["include/opencv2/**/*.h*"]),
+    includes = ["include/"],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+)

--- a/third_party/org_tensorflow_icu_windows_arm64.diff
+++ b/third_party/org_tensorflow_icu_windows_arm64.diff
@@ -1,0 +1,23 @@
+--- a/third_party/icu/icu.BUILD
++++ b/third_party/icu/icu.BUILD
+@@ -58,6 +58,10 @@ cc_library(
+         ":windows": [
+             "/utf-8",
+             "/DLOCALE_ALLOW_NEUTRAL_NAMES=0",
+         ],
++        ":windows_arm64": [
++            "/utf-8",
++            "/DLOCALE_ALLOW_NEUTRAL_NAMES=0",
++        ],
+         "//conditions:default": [],
+     }),
+@@ -83,4 +87,9 @@ config_setting(
+ config_setting(
+     name = "windows",
+     values = {"cpu": "x64_windows"},
+ )
++
++config_setting(
++    name = "windows_arm64",
++    values = {"cpu": "arm64_windows"},
++)

--- a/third_party/pffft.diff
+++ b/third_party/pffft.diff
@@ -1,0 +1,15 @@
+--- a/pffft.c
++++ b/pffft.c
+@@ -174,7 +174,11 @@
+ #  define VALIGNED(ptr) ((((long long)(ptr)) & 0x3) == 0)
+ #else
+ #  if !defined(PFFFT_SIMD_DISABLE)
+-#    warning "building with simd disabled !\n";
++#    ifdef _MSC_VER
++#      pragma message("building with simd disabled !")
++#    else
++#      warning "building with simd disabled !\n";
++#    endif
+ #    define PFFFT_SIMD_DISABLE // fallback to scalar code
+ #  endif
+ #endif

--- a/third_party/pthreadpool.diff
+++ b/third_party/pthreadpool.diff
@@ -1,0 +1,15 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -68,7 +68,9 @@ cc_library(
+         "include/pthreadpool.h",
+     ],
+-    copts = [
+-        "-std=c11",
+-    ] + select({
++    copts = select({
++        ":windows_x86_64": ["/std:c11", "/experimental:c11atomics"],
++        ":windows_arm64": ["/std:c11", "/experimental:c11atomics"],
++        "//conditions:default": ["-std=c11"],
++    }) + select({
+         ":optimized_build": ["-O2"],
+         "//conditions:default": [],

--- a/third_party/xnnpack_windows_arm64.diff
+++ b/third_party/xnnpack_windows_arm64.diff
@@ -1,0 +1,311 @@
+--- a/build_config/BUILD.bazel
++++ b/build_config/BUILD.bazel
+@@ -145,6 +145,13 @@
+     name = "windows_aarch64",
+     values = {
+          "cpu": "aarch64_windows",
++    },
++)
++
++config_setting(
++    name = "windows_arm64",
++    values = {
++         "cpu": "arm64_windows",
+     },
+ )
+ 
+@@ -338,6 +345,7 @@
+         ":ios_sim_arm64",
+         ":linux_arm64",
+         ":macos_arm64",
++        ":windows_arm64",
+         ":tvos_arm64",
+         ":watchos_arm64_32",
+     ],
+--- a/build_defs.bzl
++++ b/build_defs.bzl
+@@ -377,6 +377,7 @@
+             "//build_config:windows_x86_64_mingw": gcc_copts,
+             "//build_config:windows_x86_64_msys": gcc_copts,
+             "//build_config:windows_x86_64": msvc_copts,
++            "//build_config:windows_arm64": msvc_copts,
+             "//conditions:default": gcc_copts,
+         }) + select({
+             "//:optimized_build": optimized_copts,
+--- a/build_params.bzl
++++ b/build_params.bzl
+@@ -345,17 +345,24 @@
+                 "-march=armv8.2-a+fp16",
+                 "-mfpu=neon-fp-armv8",
+             ],
++            "//build_config:windows_arm64": [],
+             "//build_config:aarch64": ["-march=armv8.2-a+fp16"],
+             "//conditions:default": [],
+         }),
+     ),
+     "neonfp16arith_aarch64": _create_params(
+         cond = "//:arm_aarch64_fp16_vector_enabled",
+-        copts = ["-march=armv8.2-a+fp16"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+fp16"],
++        }),
+     ),
+     "neonbf16": _create_params(
+         cond = "//build_config:aarch64",
+-        copts = ["-march=armv8.2-a+bf16"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+bf16"],
++        }),
+     ),
+     "neondotfp16arith": _create_params(
+         cond = "//:arm_neondotfp16_enabled",
+@@ -365,6 +372,7 @@
+                 "-march=armv8.2-a+dotprod+fp16",
+                 "-mfpu=neon-fp-armv8",
+             ],
++            "//build_config:windows_arm64": [],
+             "//build_config:aarch64": ["-march=armv8.2-a+dotprod+fp16"],
+             "//conditions:default": [],
+         }),
+@@ -377,34 +385,47 @@
+                 "-march=armv8.2-a+dotprod",
+                 "-mfpu=neon-fp-armv8",
+             ],
++            "//build_config:windows_arm64": [],
+             "//build_config:aarch64": ["-march=armv8.2-a+dotprod"],
+             "//conditions:default": [],
+         }),
+     ),
+     "neondot_aarch64": _create_params(
+         cond = "//:arm_aarch64_dotprod_enabled",
+-        copts = ["-march=armv8.2-a+dotprod"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+dotprod"],
++        }),
+         extra_deps = xnnpack_if_kleidiai_enabled([
+             "@KleidiAI//kai/ukernels/matmul:matmul",
+         ]),
+     ),
+     "neoni8mm": _create_params(
+         cond = "//:arm_i8mm_enabled",
+-        copts = ["-march=armv8.2-a+i8mm+fp16"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+i8mm+fp16"],
++        }),
+         extra_deps = xnnpack_if_kleidiai_enabled([
+             "@KleidiAI//kai/ukernels/matmul:matmul",
+         ]),
+     ),
+     "neonsme": _create_params(
+         cond = "//:arm_sme_enabled",
+-        copts = ["-march=armv8.2-a+sve+sve2"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+sve+sve2"],
++        }),
+         extra_deps = xnnpack_if_kleidiai_enabled([
+             "@KleidiAI//kai/ukernels/matmul:matmul",
+         ]),
+     ),
+     "neonsme2": _create_params(
+         cond = "//:arm_sme2_enabled",
+-        copts = ["-march=armv8.2-a+sve+sve2"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+sve+sve2"],
++        }),
+         extra_deps = xnnpack_if_kleidiai_enabled([
+             "@KleidiAI//kai/ukernels/matmul:matmul",
+         ]),
+@@ -419,7 +440,10 @@
+     ),
+     "aarch64": _create_params(
+         cond = "//build_config:aarch64",
+-        copts = ["-march=armv8.2-a+fp16+dotprod"],
++        copts = select({
++            "//build_config:windows_arm64": [],
++            "//conditions:default": ["-march=armv8.2-a+fp16+dotprod"],
++        }),
+     ),
+ 
+     # X86.
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1770,6 +1770,7 @@
+         ":xnn_enable_kleidiai_explicit_false": ":xnn_enable_kleidiai_explicit_true",
+         # Disable for Windows ARM64 unless explicitly enabled
+         "//build_config:windows_aarch64": ":xnn_enable_kleidiai_explicit_true",
++        "//build_config:windows_arm64": ":xnn_enable_kleidiai_explicit_false",
+         "//conditions:default": ":kleidiai_enabled_by_default",
+     }),
+ )
+--- a/src/configs/gemm-config.c
++++ b/src/configs/gemm-config.c
+@@ -742,13 +742,27 @@
+         f32_gemm_config->mr = 6;
+         f32_gemm_config->nr = 8;
+       #else  // !XNN_ENABLE_ASSEMBLY
+-        f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
+-        f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
+-        f32_gemm_config->init.f32 = xnn_init_f32_minmax_scalar_params;
+-        f32_gemm_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
+-        f32_gemm_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x8__neon_ld4lane_u4_prfm;
+-        f32_gemm_config->mr = 6;
+-        f32_gemm_config->nr = 8;
++        #if defined(_WIN32) && defined(_M_ARM64)
++          f32_gemm_config->linear.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_ukernel_1x4__scalar);
++          f32_gemm_config->linear.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_ukernel_4x4__scalar);
++          f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_1x4__scalar);
++          f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_4x4__scalar);
++          f32_gemm_config->relu.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_relu_ukernel_1x4__scalar);
++          f32_gemm_config->relu.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_relu_ukernel_4x4__scalar);
++          f32_gemm_config->init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_gemm_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_x32_packw_gemm_gio_ukernel_x4__scalar;
++          f32_gemm_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x4__scalar_float_u4;
++          f32_gemm_config->mr = 4;
++          f32_gemm_config->nr = 4;
++        #else
++          f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
++          f32_gemm_config->minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
++          f32_gemm_config->init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_gemm_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
++          f32_gemm_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x8__neon_ld4lane_u4_prfm;
++          f32_gemm_config->mr = 6;
++          f32_gemm_config->nr = 8;
++        #endif
+        #endif  // XNN_ENABLE_ASSEMBLY
+     #endif  // XNN_ENABLE_ASSEMBLY && !XNN_PLATFORM_IOS && !XNN_PLATFORM_MAC
+   #elif XNN_ARCH_X86 || XNN_ARCH_X86_64
+@@ -1247,13 +1261,27 @@
+         f32_igemm_config.mr = 6;
+         f32_igemm_config.nr = 8;
+       #else  // !XNN_ENABLE_ASSEMBLY
+-        f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
+-        f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
+-        f32_igemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
+-        f32_igemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
+-        f32_igemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x8__neon_ld4lane_u4_prfm;
+-        f32_igemm_config.mr = 6;
+-        f32_igemm_config.nr = 8;
++        #if defined(_WIN32) && defined(_M_ARM64)
++          f32_igemm_config.linear.igemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_ukernel_1x4__scalar);
++          f32_igemm_config.linear.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_ukernel_4x4__scalar);
++          f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_1x4__scalar);
++          f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_4x4__scalar);
++          f32_igemm_config.relu.igemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_relu_ukernel_1x4__scalar);
++          f32_igemm_config.relu.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_relu_ukernel_4x4__scalar);
++          f32_igemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_igemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_x32_packw_gemm_gio_ukernel_x4__scalar;
++          f32_igemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x4__scalar_float_u4;
++          f32_igemm_config.mr = 4;
++          f32_igemm_config.nr = 4;
++        #else
++          f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
++          f32_igemm_config.minmax.igemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
++          f32_igemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_igemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
++          f32_igemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x8__neon_ld4lane_u4_prfm;
++          f32_igemm_config.mr = 6;
++          f32_igemm_config.nr = 8;
++        #endif
+        #endif  // XNN_ENABLE_ASSEMBLY
+     #endif  // XNN_ENABLE_ASSEMBLY && !XNN_PLATFORM_IOS && !XNN_PLATFORM_MAC
+   #elif XNN_ARCH_X86 || XNN_ARCH_X86_64
+@@ -1454,13 +1482,25 @@
+         f32_gemm_nr2_config->mr = 4;
+         f32_gemm_nr2_config->nr = 2;
+       #else  // !XNN_ENABLE_ASSEMBLY
+-        f32_gemm_nr2_config->minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_4x2__aarch64_neonfma_lane_ld64);
+-        f32_gemm_nr2_config->minmax.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_4x2__aarch64_neonfma_lane_ld64);
+-        f32_gemm_nr2_config->init.f32 = xnn_init_f32_minmax_scalar_params;
+-        f32_gemm_nr2_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
+-        f32_gemm_nr2_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x2__neon_ld2lane_u2_prfm;
+-        f32_gemm_nr2_config->mr = 4;
+-        f32_gemm_nr2_config->nr = 2;
++        #if defined(_WIN32) && defined(_M_ARM64)
++          f32_gemm_nr2_config->linear.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_ukernel_4x2__scalar);
++          f32_gemm_nr2_config->linear.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_ukernel_4x2__scalar);
++          f32_gemm_nr2_config->minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_4x2__scalar);
++          f32_gemm_nr2_config->minmax.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_4x2__scalar);
++          f32_gemm_nr2_config->init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_gemm_nr2_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_x32_packw_gemm_gio_ukernel_x2__scalar;
++          f32_gemm_nr2_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x2__scalar_float_u4;
++          f32_gemm_nr2_config->mr = 4;
++          f32_gemm_nr2_config->nr = 2;
++        #else
++          f32_gemm_nr2_config->minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_gemm_minmax_ukernel_4x2__aarch64_neonfma_lane_ld64);
++          f32_gemm_nr2_config->minmax.igemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_IGEMM_UKERNEL(xnn_f32_igemm_minmax_ukernel_4x2__aarch64_neonfma_lane_ld64);
++          f32_gemm_nr2_config->init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_gemm_nr2_config->pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_gemm_gio_w;
++          f32_gemm_nr2_config->pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x32_packw_gemm_goi_ukernel_x2__neon_ld2lane_u2_prfm;
++          f32_gemm_nr2_config->mr = 4;
++          f32_gemm_nr2_config->nr = 2;
++        #endif
+        #endif  // XNN_ENABLE_ASSEMBLY
+     #endif  // XNN_ENABLE_ASSEMBLY && !XNN_PLATFORM_IOS && !XNN_PLATFORM_MAC
+   #elif XNN_ARCH_X86 || XNN_ARCH_X86_64
+@@ -1634,13 +1674,22 @@
+       f32_qc4w_gemm_config.nr = 4;
+     }
+   #elif XNN_ARCH_ARM64
+-    f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
+-    f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_4x8__aarch64_neonfma_lane_ld128);
+-    f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
+-    f32_qc4w_gemm_config.init.f32_qc4w = xnn_init_f32_qc4w_minmax_scalar_params;
+-    f32_qc4w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_pack_f32_qc4w_gemm_goi_w;
+-    f32_qc4w_gemm_config.mr = 6;
+-    f32_qc4w_gemm_config.nr = 8;
++    #if defined(_WIN32) && defined(_M_ARM64)
++      f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_1x4__scalar);
++      f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_4x4__scalar);
++      f32_qc4w_gemm_config.init.f32_qc4w = xnn_init_f32_qc4w_minmax_scalar_params;
++      f32_qc4w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_pack_f32_qc4w_gemm_goi_w;
++      f32_qc4w_gemm_config.mr = 4;
++      f32_qc4w_gemm_config.nr = 4;
++    #else
++      f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld128);
++      f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_4x8__aarch64_neonfma_lane_ld128);
++      f32_qc4w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc4w_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld128);
++      f32_qc4w_gemm_config.init.f32_qc4w = xnn_init_f32_qc4w_minmax_scalar_params;
++      f32_qc4w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_pack_f32_qc4w_gemm_goi_w;
++      f32_qc4w_gemm_config.mr = 6;
++      f32_qc4w_gemm_config.nr = 8;
++    #endif
+   #elif XNN_ARCH_X86 || XNN_ARCH_X86_64
+     const struct xnn_hardware_config* hardware_config = xnn_init_hardware_config();
+     assert(hardware_config != NULL);
+@@ -1781,13 +1830,23 @@
+         f32_qc8w_gemm_config.mr = 6;
+         f32_qc8w_gemm_config.nr = 8;
+       #else  // !XNN_ENABLE_ASSEMBLY
+-        f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld64);
+-        f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld64);
+-        f32_qc8w_gemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
+-        f32_qc8w_gemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_qs8w_gemm_gio_w;
+-        f32_qc8w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x8_packw_gemm_goi_ukernel_x8__scalar_u2;
+-        f32_qc8w_gemm_config.mr = 6;
+-        f32_qc8w_gemm_config.nr = 8;
++        #if defined(_WIN32) && defined(_M_ARM64)
++          f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_1x4__scalar);
++          f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(4)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_4x4__scalar);
++          f32_qc8w_gemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_qc8w_gemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_qs8w_gemm_gio_w;
++          f32_qc8w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x8_packw_gemm_goi_ukernel_x4__scalar_u2;
++          f32_qc8w_gemm_config.mr = 4;
++          f32_qc8w_gemm_config.nr = 4;
++        #else
++          f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(1)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_1x8__aarch64_neonfma_lane_ld64);
++          f32_qc8w_gemm_config.minmax.gemm[XNN_MR_TO_INDEX(6)] = XNN_INIT_HMP_GEMM_UKERNEL(xnn_f32_qc8w_gemm_minmax_ukernel_6x8__aarch64_neonfma_lane_ld64);
++          f32_qc8w_gemm_config.init.f32 = xnn_init_f32_minmax_scalar_params;
++          f32_qc8w_gemm_config.pack_gemm_gio = (xnn_packw_gemm_gio_ukernel_fn) xnn_pack_f32_qs8w_gemm_gio_w;
++          f32_qc8w_gemm_config.pack_gemm_goi = (xnn_packw_gemm_goi_ukernel_fn) xnn_x8_packw_gemm_goi_ukernel_x8__scalar_u2;
++          f32_qc8w_gemm_config.mr = 6;
++          f32_qc8w_gemm_config.nr = 8;
++        #endif
+       #endif  // XNN_ENABLE_ASSEMBLY
+     #endif  // XNN_ENABLE_ASSEMBLY && !XNN_PLATFORM_IOS && !XNN_PLATFORM_MAC
+   #elif XNN_ARCH_X86 || XNN_ARCH_X86_64


### PR DESCRIPTION
**PR Summary:**
This PR enables native Windows ARM64 (WoA) support in MediaPipe using MSVC.

**Changes:**

1. **Build and platform:**

    - New `windows_arm64` Bazel config and platform
    - Updated `platform_mappings` for arm64_windows
    - `.bazelrc` configuration with ARM64‑specific and MSVC flags

2. **Third party dependency changes:**

   - ARM64 support/fixes for gflags, XNNPACK, cpuinfo, pthreadpool, pffft, ICU
   - Added `opencv_windows_arm64 BUILD` and repo for prebuilt OpenCV ARM64

3. **Test fixes:**

    - Guarded tests relying on pthreads or unsupported MSVC ARM64 behavior

4. **Packaging:**

    - `setup.py` auto‑enables --config=windows_arm64 on native WoA
    - GPU and ODML converter disabled on Windows ARM64