### PR TITLE
Add OSS-Fuzz integration: rules_fuzzing scaffold and CalculatorGraphConfig harness

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -966,3 +966,16 @@ http_archive(
     strip_prefix = "curl-8.10.1",
     url = "https://curl.haxx.se/download/curl-8.10.1.tar.gz",
 )
+http_archive(
+    name = "rules_fuzzing",
+    sha256 = "2cc83f91e3048d275f3ebc8b627ebca5c0fc401b3f093a4de398b11ec3e21137",
+    strip_prefix = "rules_fuzzing-v0.8.0",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.8.0/rules_fuzzing-v0.8.0.tar.gz"],
+)
+
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+rules_fuzzing_dependencies()
+load("@rules_fuzzing//fuzzing:init.bzl", "rules_fuzzing_init")
+rules_fuzzing_init()
+load("@fuzzing_py_deps//:requirements.bzl", "install_deps")
+install_deps()

--- a/mediapipe/framework/fuzz/BUILD
+++ b/mediapipe/framework/fuzz/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2026 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
+
+package(default_visibility = ["//visibility:private"])
+
+cc_fuzz_test(
+    name = "calculator_graph_config_fuzz",
+    srcs = ["calculator_graph_config_fuzz.cc"],
+    corpus = glob(["corpus/**"], allow_empty = True),
+    deps = [
+        "//mediapipe/framework:calculator_cc_proto",
+        "//mediapipe/framework:calculator_graph",
+    ],
+)

--- a/mediapipe/framework/fuzz/calculator_graph_config_fuzz.cc
+++ b/mediapipe/framework/fuzz/calculator_graph_config_fuzz.cc
@@ -1,0 +1,38 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// libFuzzer harness for the CalculatorGraphConfig protobuf parser surface.
+//
+// First-cut harness: raw byte input parsed via CalculatorGraphConfig::ParseFromArray
+// then handed to CalculatorGraph::Initialize. Memory-safety violations in the
+// proto parsing or graph initialization paths surface as ASAN/UBSAN crashes.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "mediapipe/framework/calculator.pb.h"
+#include "mediapipe/framework/calculator_graph.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  mediapipe::CalculatorGraphConfig config;
+  if (!config.ParseFromArray(data, static_cast<int>(size))) {
+    // Wire-format rejected by protobuf — not an interesting input.
+    return 0;
+  }
+  mediapipe::CalculatorGraph graph;
+  // absl::Status from Initialize is intentionally discarded; we only crash
+  // on memory-safety violations, not on semantic errors.
+  (void)graph.Initialize(config);
+  return 0;
+}


### PR DESCRIPTION
This PR adds an initial OSS-Fuzz integration for MediaPipe, targeting the
CalculatorGraphConfig protobuf parser surface.

## What this adds

Three files under mediapipe/framework/fuzz/:

- BUILD — defines a cc_fuzz_test target using rules_fuzzing v0.8.0
- calculator_graph_config_fuzz.cc — libFuzzer harness that parses raw bytes as
  CalculatorGraphConfig via ParseFromArray, then passes valid configs to
  CalculatorGraph::Initialize. Memory-safety violations in either path surface
  as AddressSanitizer crashes.
- Corpus directory placeholder (empty; OSS-Fuzz ClusterFuzz will populate it
  over time via coverage-guided mutation)

Plus additions to WORKSPACE to load rules_fuzzing v0.8.0 and its dependencies.

## Build notes

The harness requires two build flags for the OSS-Fuzz base-builder environment:

- --host_cxxopt=-stdlib=libc++ and --host_linkopt=-stdlib=libc++ — the base-builder
  image ships gcc-9 on Ubuntu 20.04 whose libstdc++ lacks the C++20 <compare>
  header required by MediaPipe's pinned abseil. clang-22 + libc++ is present and
  supports it cleanly.
- --define=MEDIAPIPE_DISABLE_GPU=1 — activates MediaPipe's built-in no-GPU build
  path, substituting gpu_shared_data_internal_stub for the EGL-dependent GPU
  service layer. The CalculatorGraphConfig parse surface does not require GPU.

Both flags are set in the companion OSS-Fuzz project's build.sh (PR against
google/oss-fuzz submitted separately).

## Testing

The fuzzer binary was built locally using helper.py build_fuzzers and smoke-tested
via helper.py reproduce against five inputs (empty proto, minimal valid proto,
random bytes, and two structured text-format inputs). All five inputs executed
cleanly with zero AddressSanitizer findings across 100 iterations each.
