### PR TITLE
docs: fix typo recieve to receive in packet_processor.h

### DIFF
--- a/mediapipe/framework/tool/switch/packet_processor.h
+++ b/mediapipe/framework/tool/switch/packet_processor.h
@@ -40,7 +40,7 @@ class PacketProducer {
  public:
   virtual ~PacketProducer() = default;
 
-  // Connects a consumer to recieve packets from this producer.
+  // Connects a consumer to receive packets from this producer.
   virtual void SetConsumer(PacketConsumer* consumer) = 0;
 };
 
@@ -61,7 +61,7 @@ class SidePacketProducer {
  public:
   virtual ~SidePacketProducer() = default;
 
-  // Connects a consumer to recieve packets from this producer.
+  // Connects a consumer to receive packets from this producer.
   virtual void SetSideConsumer(SidePacketConsumer* consumer) = 0;
 };
 


### PR DESCRIPTION
Fixed a spelling error in the comments of packet_processor.h ('recieve' -> 'receive').