### PR TITLE
Clarify Rect coordinate documentation for JavaScript API

### DIFF
--- a/mediapipe/tasks/web/components/containers/rect.d.ts
+++ b/mediapipe/tasks/web/components/containers/rect.d.ts
@@ -15,8 +15,10 @@
  */
 
 /**
- * Defines a rectangle, used e.g. as part of detection results or as input
- * region-of-interest.
+ * Defines a rectangle using absolute pixel coordinates, used e.g. as part of
+ * detection results or as input region-of-interest.
+ *
+ * The origin is on the top-left corner of the image.
  */
 export declare interface Rect {
   left: number;


### PR DESCRIPTION
Fixes #6146.

Clarifies that `Rect` uses absolute pixel coordinates, while `RectF` uses normalized coordinates relative to the image dimensions.