### PR TITLE
Bound col_starts indices in TrackingData motion-vector decoding (heap OOB read)

### DIFF
--- a/mediapipe/util/tracking/tracking.cc
+++ b/mediapipe/util/tracking/tracking.cc
@@ -3218,6 +3218,15 @@ void MotionVectorFrameFromTrackingData(const TrackingData& tracking_data,
     for (int r = motion_data.col_starts(c),
              r_end = motion_data.col_starts(c + 1);
          r < r_end; ++r) {
+      // Guard against a malformed TrackingData whose col_starts reference
+      // indices outside the dependent repeated fields (heap OOB read
+      // otherwise). col_starts is attacker-controlled and independent of the
+      // row_indices/vector_data/track_id sizes.
+      if (r < 0 || r >= motion_data.row_indices_size() ||
+          2 * r + 1 >= motion_data.vector_data_size() ||
+          (long_tracks && r >= motion_data.track_id_size())) {
+        break;
+      }
       MotionVector motion_vector;
 
       const float y = motion_data.row_indices(r);
@@ -3278,6 +3287,12 @@ void FeatureAndDescriptorFromTrackingData(
     for (int r = motion_data.col_starts(c),
              r_end = motion_data.col_starts(c + 1);
          r < r_end; ++r) {
+      // Same guard as MotionVectorFrameFromTrackingData: reject col_starts
+      // values that fall outside the dependent repeated fields.
+      if (r < 0 || r >= motion_data.feature_descriptors_size() ||
+          r >= motion_data.row_indices_size()) {
+        break;
+      }
       const std::string& descriptor = motion_data.feature_descriptors(r).data();
 
       if (absl::c_all_of(descriptor, [](char c) { return c == 0; })) {


### PR DESCRIPTION
### Problem

`MotionVectorFrameFromTrackingData()` (and the sibling
`FeatureAndDescriptorFromTrackingData()`) in `mediapipe/util/tracking/tracking.cc` decode
a compressed-sparse-column layout from a `TrackingData` proto:

```cpp
for (int c = 0; c < motion_data.col_starts_size() - 1; ++c) {
  for (int r = motion_data.col_starts(c),
           r_end = motion_data.col_starts(c + 1);   // attacker-controlled bound
       r < r_end; ++r) {
    const float y  = motion_data.row_indices(r);    // r unchecked vs row_indices_size()
    const float dx = motion_data.vector_data(2 * r);     // unchecked vs vector_data_size()
    const float dy = motion_data.vector_data(2 * r + 1);
    ...
    if (long_tracks) motion_vector.track_id = motion_data.track_id(r);  // unchecked
  }
}
```

`col_starts`, `row_indices`, `vector_data`, `track_id` (and `feature_descriptors`) are
independent `repeated` fields; nothing constrains `col_starts(c+1)` to the sizes of the
others. A `TrackingData` whose `col_starts` values exceed the dependent arrays drives `r`
(and `2*r`) past the end of each `RepeatedField`. `RepeatedField::Get(int)` is bounds
checked only when the bounds-check mode is `kAbort`; with the default mode it is an
unchecked `elements()[index]` (the `ABSL_DCHECK` is a no-op under `NDEBUG`), so this is a
heap out-of-bounds read in opt builds. Out-of-bounds heap contents are emitted as box
coordinates; large values crash.

This is reachable from deserialized `TrackingData`: `BoxTracker::ReadChunkFromCache`
parses `chunk_*` cache files (`box_tracker.cc`) and feeds them here, and
`BoxTrackerCalculator` accepts `TrackingData` on its `TRACKING` input stream. The
binary-decode path (`FlowPackager::DecodeTrackingData`) has a consistency check
(`ABSL_CHECK_EQ(num_vectors, col_starts.back())`), but these direct-proto paths do not.

### Fix

Before dereferencing, reject an index `r` that falls outside the dependent repeated
fields. Because `r` increases monotonically within the inner loop, breaking on the first
out-of-range index is sufficient and changes nothing for well-formed input. The same guard
is added to `FeatureAndDescriptorFromTrackingData`.
