### PR TITLE
Improve hand-ROI size estimation with a data-driven formula (fixes #5373)

### DIFF
--- a/mediapipe/modules/holistic_landmark/calculators/hand_detections_from_pose_to_rects_calculator.cc
+++ b/mediapipe/modules/holistic_landmark/calculators/hand_detections_from_pose_to_rects_calculator.cc
@@ -108,15 +108,17 @@ HandDetectionsFromPoseToRectsCalculator::DetectionToNormalizedRect(
 
   // Bounding box size from a data-driven formula fit on the Panoptic Hand DB
   // (Simon et al., 2017). The original heuristic used 2*dist(middle, wrist),
-  // which systematically mis-scales the ROI when the hand is not parallel to the
-  // camera. A two-term linear fit over the available keypoints - the wrist->
-  // middle distance and the index->pinky knuckle span - halves the scale error
-  // (30.4% -> 18.7% relative) and improves ROI IoU on the test set.
-  // The (width/height) factor makes the distances isotropic; the downstream
-  // RectTransformationCalculator still applies the unchanged 2.7x expansion.
+  // which systematically under-scales the ROI when the hand is not parallel to
+  // the camera. A two-term linear fit over the available keypoints - the wrist->
+  // middle distance and the index->pinky knuckle span - cuts the ROI scale error
+  // (30.4% -> 17.4% relative), raises ROI IoU 58.8% -> 65.9% and drops badly
+  // cropped hands (IoU < 50%) from 30% to 10% on the held-out set.
+  //
+  // All coordinates here are in PIXELS (x*width, y*height), so the distances are
+  // already isotropic - no aspect-ratio correction is applied or needed. The
+  // downstream RectTransformationCalculator still applies the unchanged 2.7x
+  // expansion (the coefficients below are post-divided by 2.7).
   // See https://github.com/sign-language-processing/mediapipe-hand-crop-fix
-  const float aspect = static_cast<float>(image_size->first) /
-                       static_cast<float>(image_size->second);
   const float d_wrist_middle =
       std::sqrt((x_middle - x_wrist) * (x_middle - x_wrist) +
                 (y_middle - y_wrist) * (y_middle - y_wrist));
@@ -124,7 +126,7 @@ HandDetectionsFromPoseToRectsCalculator::DetectionToNormalizedRect(
       std::sqrt((x_index - x_pinky) * (x_index - x_pinky) +
                 (y_index - y_pinky) * (y_index - y_pinky));
   const float box_size =
-      aspect * (0.79494f * d_wrist_middle + 0.49580f * d_index_pinky);
+      1.36807f * d_wrist_middle + 0.57733f * d_index_pinky;
 
   // Set resulting bounding box.
   rect->set_x_center(center_x / image_size->first);

--- a/mediapipe/modules/holistic_landmark/calculators/hand_detections_from_pose_to_rects_calculator.cc
+++ b/mediapipe/modules/holistic_landmark/calculators/hand_detections_from_pose_to_rects_calculator.cc
@@ -106,11 +106,25 @@ HandDetectionsFromPoseToRectsCalculator::DetectionToNormalizedRect(
   const float center_x = x_middle;
   const float center_y = y_middle;
 
-  // Bounding box size as double distance from middle finger to wrist.
-  const float box_size =
+  // Bounding box size from a data-driven formula fit on the Panoptic Hand DB
+  // (Simon et al., 2017). The original heuristic used 2*dist(middle, wrist),
+  // which systematically mis-scales the ROI when the hand is not parallel to the
+  // camera. A two-term linear fit over the available keypoints - the wrist->
+  // middle distance and the index->pinky knuckle span - halves the scale error
+  // (30.4% -> 18.7% relative) and improves ROI IoU on the test set.
+  // The (width/height) factor makes the distances isotropic; the downstream
+  // RectTransformationCalculator still applies the unchanged 2.7x expansion.
+  // See https://github.com/sign-language-processing/mediapipe-hand-crop-fix
+  const float aspect = static_cast<float>(image_size->first) /
+                       static_cast<float>(image_size->second);
+  const float d_wrist_middle =
       std::sqrt((x_middle - x_wrist) * (x_middle - x_wrist) +
-                (y_middle - y_wrist) * (y_middle - y_wrist)) *
-      2.0;
+                (y_middle - y_wrist) * (y_middle - y_wrist));
+  const float d_index_pinky =
+      std::sqrt((x_index - x_pinky) * (x_index - x_pinky) +
+                (y_index - y_pinky) * (y_index - y_pinky));
+  const float box_size =
+      aspect * (0.79494f * d_wrist_middle + 0.49580f * d_index_pinky);
 
   // Set resulting bounding box.
   rect->set_x_center(center_x / image_size->first);


### PR DESCRIPTION
Fixes https://github.com/google-ai-edge/mediapipe/issues/5373

## Summary

In Holistic, the hand re-crop ROI **size** is set to `2 * dist(middle, wrist)`
(then a fixed `2.7x` expansion). This systematically under-scales the ROI when
the hand is **not parallel to the camera** — common in sign-language and gesture
input — so the hand-landmark model gets a too-tight crop and the keypoints
degrade (see #5373).

This PR replaces only the size term with a small **data-driven formula** over
keypoints the calculator already has (wrist, index, pinky). No new model, no
extra runtime cost, no graph changes — a localized change to
`HandDetectionsFromPoseToRectsCalculator`:

```cpp
// coordinates are already in pixels (x*W, y*H), so the distances are isotropic
box_size = 1.36807 * dist(middle, wrist) + 0.57733 * dist(index, pinky);
```

`middle = (2*index + pinky)/3`. It is the original wrist→middle term, recalibrated,
plus an **index→pinky knuckle-span** term that captures hand size under
foreshortening. The downstream `RectTransformationCalculator`
(`scale=2.7, shift_y=-0.1, square_long`) is unchanged.

## Why two terms, and why no aspect factor

The wrist→middle distance alone tracks an outstretched hand but collapses under
foreshortening (the knuckle span stays informative when the hand points toward the
camera). Both distances are computed in **pixel space** (`x*W, y*H`), which is
isotropic, so the box size depends only on the hand's pixel size — **not** on the
image aspect ratio. (An earlier revision of this PR carried a spurious `W/H`
factor from an inconsistent normalization during fitting; it was refit in a single
isotropic frame to remove it. The old factor made the crop size scale with the
frame's aspect ratio, which collapsed ROI IoU to ~16% on portrait input.)

## Derivation & results

Coefficients were obtained by pruning a Kolmogorov–Arnold Network to a symbolic
linear form, fit on the CMU Panoptic Hand DB. On the held-out test set
(n=643, true pixel-space rotated-box IoU):

| Metric | Original | This PR |
|---|---|---|
| ROI IoU | 58.8% | **65.9%** |
| Scale error | 30.4% | **17.4%** |
| Badly cropped (IoU < 50%) | 29.9% | **10.4%** |
| Worst-case (min) IoU | 3.4% | **6.7%** |

Full code, the isotropic data pipeline, and ablations:
https://github.com/sign-language-processing/mediapipe-hand-crop-fix

A companion PR (#6314) adds a small learned calculator with higher accuracy, for
those willing to ship a tiny (~650-param) network.

## Downstream hand-keypoint accuracy

Beyond ROI overlap, we measured the effect on the *final* hand keypoints: run the
real hand re-crop + hand-landmark models on each ROI and compare the predicted 21
keypoints to the manual gold annotations (n=643; error normalized by gold
hand-box size, lower is better).

| ROI source | ROI → landmark (no re-crop) | full pipeline (with re-crop) |
|---|---|---|
| Original heuristic | 10.55% | 6.57% |
| This formula | **5.68%**  (−46%, p≈1e-63) | **5.73%**  (p≈0.13) |
| Oracle ROI (from gold keypoints) | 4.45% | 4.39% |

Fed straight into the landmark model the better box cuts keypoint error ~46% and
nearly reaches the oracle. In the full pipeline MediaPipe's re-crop model already
compensates for much of the original ROI's error, so the end-to-end delta is
smaller — but the ROI is unambiguously better, and the aspect-ratio robustness
matters whenever input is not landscape.

## Latency

Negligible — two distances and a weighted sum per hand, immeasurable next to the
pipeline's neural inferences (~71 ms per Holistic frame at 1920×1080).
