### PR TITLE
Multi-person Holistic (graph-native)

### DIFF
--- a/mediapipe/modules/holistic_landmark/BUILD
+++ b/mediapipe/modules/holistic_landmark/BUILD
@@ -268,3 +268,41 @@ mediapipe_simple_subgraph(
         "//mediapipe/modules/pose_landmark:pose_landmark_cpu",
     ],
 )
+
+mediapipe_simple_subgraph(
+    name = "holistic_body_from_pose_cpu",
+    graph = "holistic_body_from_pose_cpu.pbtxt",
+    register_as = "HolisticBodyFromPoseCpu",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":face_detection_front_detections_to_roi",
+        ":face_landmarks_from_pose_to_recrop_roi",
+        ":hand_landmarks_from_pose_to_recrop_roi",
+        ":hand_recrop_by_roi_cpu",
+        ":hand_visibility_from_hand_landmarks_from_pose",
+        "//mediapipe/calculators/core:gate_calculator",
+        "//mediapipe/calculators/core:split_proto_list_calculator",
+        "//mediapipe/calculators/image:image_properties_calculator",
+        "//mediapipe/modules/face_detection:face_detection_short_range_by_roi_cpu",
+        "//mediapipe/modules/face_landmark:face_landmark_cpu",
+        "//mediapipe/modules/hand_landmark:hand_landmark_cpu",
+    ],
+)
+
+mediapipe_simple_subgraph(
+    name = "holistic_landmark_multi_cpu",
+    graph = "holistic_landmark_multi_cpu.pbtxt",
+    register_as = "HolisticLandmarkMultiCpu",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":holistic_body_from_pose_cpu",
+        "//mediapipe/calculators/core:begin_loop_calculator",
+        "//mediapipe/calculators/core:clip_vector_size_calculator",
+        "//mediapipe/calculators/core:constant_side_packet_calculator",
+        "//mediapipe/calculators/core:end_loop_calculator",
+        "//mediapipe/calculators/image:image_properties_calculator",
+        "//mediapipe/modules/pose_detection:pose_detection_cpu",
+        "//mediapipe/modules/pose_landmark:pose_detection_to_roi",
+        "//mediapipe/modules/pose_landmark:pose_landmark_by_roi_cpu",
+    ],
+)

--- a/mediapipe/modules/holistic_landmark/holistic_body_from_pose_cpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/holistic_body_from_pose_cpu.pbtxt
@@ -1,0 +1,176 @@
+# Predicts left/right hand + face landmarks for a SINGLE person, given that
+# person's pose landmarks. This is the per-person "body" portion of holistic,
+# factored out of HolisticLandmarkCpu so it can be looped over several people.
+#
+# Unlike the single-person HandLandmarksFromPoseCpu / FaceLandmarksFromPoseCpu
+# subgraphs, this graph is STATELESS: it does not use HandTracking / FaceTracking
+# (which carry a previous-frame landmark back-edge). Per-frame, per-person ROIs
+# are taken directly from the re-crop / detection stage. Statelessness is
+# required because this graph is run inside a BeginLoop/EndLoop over people, and
+# a per-frame back-edge inside the loop would leak state between people.
+#
+# EXAMPLE:
+#   node {
+#     calculator: "HolisticBodyFromPoseCpu"
+#     input_stream: "IMAGE:image"
+#     input_stream: "POSE_LANDMARKS:pose_landmarks"
+#     input_side_packet: "REFINE_FACE_LANDMARKS:refine_face_landmarks"
+#     output_stream: "LEFT_HAND_LANDMARKS:left_hand_landmarks"
+#     output_stream: "RIGHT_HAND_LANDMARKS:right_hand_landmarks"
+#     output_stream: "FACE_LANDMARKS:face_landmarks"
+#   }
+
+type: "HolisticBodyFromPoseCpu"
+
+# CPU image. (ImageFrame)
+input_stream: "IMAGE:image"
+# A single person's 33 pose landmarks. (NormalizedLandmarkList)
+input_stream: "POSE_LANDMARKS:pose_landmarks"
+
+# Whether to refine face landmarks (attention mesh + irises). (bool)
+input_side_packet: "REFINE_FACE_LANDMARKS:refine_face_landmarks"
+
+# 21 left hand landmarks. (NormalizedLandmarkList)
+output_stream: "LEFT_HAND_LANDMARKS:left_hand_landmarks"
+# 21 right hand landmarks. (NormalizedLandmarkList)
+output_stream: "RIGHT_HAND_LANDMARKS:right_hand_landmarks"
+# 468 face landmarks. (NormalizedLandmarkList)
+output_stream: "FACE_LANDMARKS:face_landmarks"
+
+# Image size, shared by the hand and face ROI stages.
+node {
+  calculator: "ImagePropertiesCalculator"
+  input_stream: "IMAGE:image"
+  output_stream: "SIZE:image_size"
+}
+
+# ---------------------------------------------------------------------------
+# Left hand.
+# ---------------------------------------------------------------------------
+node {
+  calculator: "SplitNormalizedLandmarkListCalculator"
+  input_stream: "pose_landmarks"
+  output_stream: "left_hand_landmarks_from_pose"
+  options: {
+    [mediapipe.SplitVectorCalculatorOptions.ext] {
+      ranges: { begin: 15 end: 16 }
+      ranges: { begin: 17 end: 18 }
+      ranges: { begin: 19 end: 20 }
+      combine_outputs: true
+    }
+  }
+}
+node {
+  calculator: "HandVisibilityFromHandLandmarksFromPose"
+  input_stream: "HAND_LANDMARKS_FROM_POSE:left_hand_landmarks_from_pose"
+  output_stream: "VISIBILITY:left_hand_visibility"
+}
+node {
+  calculator: "GateCalculator"
+  input_stream: "left_hand_landmarks_from_pose"
+  input_stream: "ALLOW:left_hand_visibility"
+  output_stream: "ensured_left_hand_landmarks_from_pose"
+}
+node {
+  calculator: "HandLandmarksFromPoseToRecropRoi"
+  input_stream: "HAND_LANDMARKS_FROM_POSE:ensured_left_hand_landmarks_from_pose"
+  input_stream: "IMAGE_SIZE:image_size"
+  output_stream: "ROI:left_hand_roi_from_pose"
+}
+node {
+  calculator: "HandRecropByRoiCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:left_hand_roi_from_pose"
+  output_stream: "HAND_ROI_FROM_RECROP:left_hand_roi_from_recrop"
+}
+node {
+  calculator: "HandLandmarkCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:left_hand_roi_from_recrop"
+  output_stream: "LANDMARKS:left_hand_landmarks"
+}
+
+# ---------------------------------------------------------------------------
+# Right hand.
+# ---------------------------------------------------------------------------
+node {
+  calculator: "SplitNormalizedLandmarkListCalculator"
+  input_stream: "pose_landmarks"
+  output_stream: "right_hand_landmarks_from_pose"
+  options: {
+    [mediapipe.SplitVectorCalculatorOptions.ext] {
+      ranges: { begin: 16 end: 17 }
+      ranges: { begin: 18 end: 19 }
+      ranges: { begin: 20 end: 21 }
+      combine_outputs: true
+    }
+  }
+}
+node {
+  calculator: "HandVisibilityFromHandLandmarksFromPose"
+  input_stream: "HAND_LANDMARKS_FROM_POSE:right_hand_landmarks_from_pose"
+  output_stream: "VISIBILITY:right_hand_visibility"
+}
+node {
+  calculator: "GateCalculator"
+  input_stream: "right_hand_landmarks_from_pose"
+  input_stream: "ALLOW:right_hand_visibility"
+  output_stream: "ensured_right_hand_landmarks_from_pose"
+}
+node {
+  calculator: "HandLandmarksFromPoseToRecropRoi"
+  input_stream: "HAND_LANDMARKS_FROM_POSE:ensured_right_hand_landmarks_from_pose"
+  input_stream: "IMAGE_SIZE:image_size"
+  output_stream: "ROI:right_hand_roi_from_pose"
+}
+node {
+  calculator: "HandRecropByRoiCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:right_hand_roi_from_pose"
+  output_stream: "HAND_ROI_FROM_RECROP:right_hand_roi_from_recrop"
+}
+node {
+  calculator: "HandLandmarkCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:right_hand_roi_from_recrop"
+  output_stream: "LANDMARKS:right_hand_landmarks"
+}
+
+# ---------------------------------------------------------------------------
+# Face.
+# ---------------------------------------------------------------------------
+node {
+  calculator: "SplitNormalizedLandmarkListCalculator"
+  input_stream: "pose_landmarks"
+  output_stream: "face_landmarks_from_pose"
+  options: {
+    [mediapipe.SplitVectorCalculatorOptions.ext] {
+      ranges: { begin: 0 end: 11 }
+    }
+  }
+}
+node {
+  calculator: "FaceLandmarksFromPoseToRecropRoi"
+  input_stream: "FACE_LANDMARKS_FROM_POSE:face_landmarks_from_pose"
+  input_stream: "IMAGE_SIZE:image_size"
+  output_stream: "ROI:face_roi_from_pose"
+}
+node {
+  calculator: "FaceDetectionShortRangeByRoiCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:face_roi_from_pose"
+  output_stream: "DETECTIONS:face_detections"
+}
+node {
+  calculator: "FaceDetectionFrontDetectionsToRoi"
+  input_stream: "DETECTIONS:face_detections"
+  input_stream: "IMAGE_SIZE:image_size"
+  output_stream: "ROI:face_roi_from_detection"
+}
+node {
+  calculator: "FaceLandmarkCpu"
+  input_stream: "IMAGE:image"
+  input_stream: "ROI:face_roi_from_detection"
+  input_side_packet: "WITH_ATTENTION:refine_face_landmarks"
+  output_stream: "LANDMARKS:face_landmarks"
+}

--- a/mediapipe/modules/holistic_landmark/holistic_landmark_multi_cpu.pbtxt
+++ b/mediapipe/modules/holistic_landmark/holistic_landmark_multi_cpu.pbtxt
@@ -1,0 +1,145 @@
+# Predicts pose + left/right hand + face landmarks for MULTIPLE people.
+#
+# Mirrors HolisticLandmarkCpu, but the single-person PoseLandmarkCpu stage is
+# replaced by multi-person pose detection followed by a per-person loop: each
+# detected person is run through PoseLandmarkByRoiCpu and the
+# HolisticBodyFromPoseCpu (hands + face) subgraph. Outputs are vectors, one
+# element per detected person.
+#
+# People are detected every frame (the pose detector is multi-person via NMS).
+# Note: cross-frame ROI association (as in hand_landmark_tracking_cpu) is NOT
+# used here on purpose: pose ROIs are square and full-body-sized, so several
+# people standing apart in a wide frame still produce heavily-overlapping ROIs
+# that ROI-IoU association would wrongly merge. Per-frame detection keeps each
+# person distinct.
+#
+# EXAMPLE:
+#   node {
+#     calculator: "HolisticLandmarkMultiCpu"
+#     input_stream: "IMAGE:input_video"
+#     input_side_packet: "MODEL_COMPLEXITY:model_complexity"
+#     input_side_packet: "REFINE_FACE_LANDMARKS:refine_face_landmarks"
+#     output_stream: "POSE_LANDMARKS:multi_pose_landmarks"
+#     output_stream: "LEFT_HAND_LANDMARKS:multi_left_hand_landmarks"
+#     output_stream: "RIGHT_HAND_LANDMARKS:multi_right_hand_landmarks"
+#     output_stream: "FACE_LANDMARKS:multi_face_landmarks"
+#   }
+
+type: "HolisticLandmarkMultiCpu"
+
+# CPU image. (ImageFrame)
+input_stream: "IMAGE:image"
+
+# Complexity of the pose landmark model: 0, 1 or 2. (int)
+input_side_packet: "MODEL_COMPLEXITY:model_complexity"
+# Whether to refine face landmarks. (bool)
+input_side_packet: "REFINE_FACE_LANDMARKS:refine_face_landmarks"
+
+# Per-person landmark vectors (std::vector<NormalizedLandmarkList>); element i
+# corresponds to person i.
+output_stream: "POSE_LANDMARKS:multi_pose_landmarks"
+output_stream: "LEFT_HAND_LANDMARKS:multi_left_hand_landmarks"
+output_stream: "RIGHT_HAND_LANDMARKS:multi_right_hand_landmarks"
+output_stream: "FACE_LANDMARKS:multi_face_landmarks"
+
+# Segmentation is disabled in multi-person mode.
+node {
+  calculator: "ConstantSidePacketCalculator"
+  output_side_packet: "PACKET:enable_segmentation"
+  options: {
+    [mediapipe.ConstantSidePacketCalculatorOptions.ext] {
+      packet { bool_value: false }
+    }
+  }
+}
+
+# Image size, used to convert pose detections to ROIs.
+node {
+  calculator: "ImagePropertiesCalculator"
+  input_stream: "IMAGE:image"
+  output_stream: "SIZE:image_size"
+}
+
+# Detect all people in the frame.
+node {
+  calculator: "PoseDetectionCpu"
+  input_stream: "IMAGE:image"
+  output_stream: "DETECTIONS:all_pose_detections"
+}
+
+# Cap the number of people.
+node {
+  calculator: "ClipDetectionVectorSizeCalculator"
+  input_stream: "all_pose_detections"
+  output_stream: "pose_detections"
+  options: {
+    [mediapipe.ClipVectorSizeCalculatorOptions.ext] { max_vec_size: 10 }
+  }
+}
+
+# Loop over each detected person.
+node {
+  calculator: "BeginLoopDetectionCalculator"
+  input_stream: "ITERABLE:pose_detections"
+  input_stream: "CLONE:0:image"
+  input_stream: "CLONE:1:image_size"
+  output_stream: "ITEM:pose_detection"
+  output_stream: "CLONE:0:image_for_person"
+  output_stream: "CLONE:1:image_size_for_person"
+  output_stream: "BATCH_END:detections_timestamp"
+}
+
+# Per-person ROI from the detection.
+node {
+  calculator: "PoseDetectionToRoi"
+  input_stream: "DETECTION:pose_detection"
+  input_stream: "IMAGE_SIZE:image_size_for_person"
+  output_stream: "ROI:pose_roi"
+}
+
+# Per-person pose landmarks within the ROI.
+node {
+  calculator: "PoseLandmarkByRoiCpu"
+  input_stream: "IMAGE:image_for_person"
+  input_stream: "ROI:pose_roi"
+  input_side_packet: "MODEL_COMPLEXITY:model_complexity"
+  input_side_packet: "ENABLE_SEGMENTATION:enable_segmentation"
+  output_stream: "LANDMARKS:person_pose_landmarks"
+}
+
+# Per-person hands + face from the pose landmarks.
+node {
+  calculator: "HolisticBodyFromPoseCpu"
+  input_stream: "IMAGE:image_for_person"
+  input_stream: "POSE_LANDMARKS:person_pose_landmarks"
+  input_side_packet: "REFINE_FACE_LANDMARKS:refine_face_landmarks"
+  output_stream: "LEFT_HAND_LANDMARKS:person_left_hand_landmarks"
+  output_stream: "RIGHT_HAND_LANDMARKS:person_right_hand_landmarks"
+  output_stream: "FACE_LANDMARKS:person_face_landmarks"
+}
+
+# Collect per-person results back into vectors.
+node {
+  calculator: "EndLoopNormalizedLandmarkListVectorCalculator"
+  input_stream: "ITEM:person_pose_landmarks"
+  input_stream: "BATCH_END:detections_timestamp"
+  output_stream: "ITERABLE:multi_pose_landmarks"
+}
+node {
+  calculator: "EndLoopNormalizedLandmarkListVectorCalculator"
+  input_stream: "ITEM:person_left_hand_landmarks"
+  input_stream: "BATCH_END:detections_timestamp"
+  output_stream: "ITERABLE:multi_left_hand_landmarks"
+}
+node {
+  calculator: "EndLoopNormalizedLandmarkListVectorCalculator"
+  input_stream: "ITEM:person_right_hand_landmarks"
+  input_stream: "BATCH_END:detections_timestamp"
+  output_stream: "ITERABLE:multi_right_hand_landmarks"
+}
+node {
+  calculator: "EndLoopNormalizedLandmarkListVectorCalculator"
+  input_stream: "ITEM:person_face_landmarks"
+  input_stream: "BATCH_END:detections_timestamp"
+  output_stream: "ITERABLE:multi_face_landmarks"
+}

--- a/mediapipe/modules/pose_detection/pose_detection_cpu.pbtxt
+++ b/mediapipe/modules/pose_detection/pose_detection_cpu.pbtxt
@@ -128,7 +128,7 @@ node {
       y_scale: 224.0
       h_scale: 224.0
       w_scale: 224.0
-      min_score_thresh: 0.5
+      min_score_thresh: 0.2
     }
   }
 }

--- a/mediapipe/python/BUILD
+++ b/mediapipe/python/BUILD
@@ -77,6 +77,7 @@ cc_library(
         "//mediapipe/modules/face_landmark:face_landmark_front_cpu",
         "//mediapipe/modules/hand_landmark:hand_landmark_tracking_cpu",
         "//mediapipe/modules/holistic_landmark:holistic_landmark_cpu",
+        "//mediapipe/modules/holistic_landmark:holistic_landmark_multi_cpu",
         "//mediapipe/modules/objectron:objectron_cpu",
         "//mediapipe/modules/palm_detection:palm_detection_cpu",
         "//mediapipe/modules/pose_detection:pose_detection_cpu",

--- a/mediapipe/python/solutions/__init__.py
+++ b/mediapipe/python/solutions/__init__.py
@@ -22,6 +22,7 @@ import mediapipe.python.solutions.face_mesh_connections
 import mediapipe.python.solutions.hands
 import mediapipe.python.solutions.hands_connections
 import mediapipe.python.solutions.holistic
+import mediapipe.python.solutions.holistic_multi
 import mediapipe.python.solutions.objectron
 import mediapipe.python.solutions.pose
 import mediapipe.python.solutions.selfie_segmentation

--- a/mediapipe/python/solutions/holistic_multi.py
+++ b/mediapipe/python/solutions/holistic_multi.py
@@ -1,0 +1,129 @@
+# Copyright 2024 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-person MediaPipe Holistic.
+
+`solutions.holistic.Holistic` is single-person: its pose stage keeps only the
+most prominent detection. `MultiHolistic` runs the `HolisticLandmarkMultiCpu`
+graph, which detects every person in the frame and runs pose + hands + face for
+each one, returning a list (one entry per person).
+
+Example:
+
+    import cv2, mediapipe as mp
+    mph = mp.solutions.holistic_multi.MultiHolistic()
+    image = cv2.cvtColor(cv2.imread('group.jpg'), cv2.COLOR_BGR2RGB)
+    result = mph.process(image)
+    for pose in result.pose_landmarks:        # one NormalizedLandmarkList / person
+        mp.solutions.drawing_utils.draw_landmarks(
+            image, pose, mp.solutions.holistic.POSE_CONNECTIONS)
+    mph.close()
+"""
+
+import collections
+import os
+from typing import List, NamedTuple
+
+import numpy as np
+
+from mediapipe.framework.formats import landmark_pb2
+from mediapipe.python import packet_creator
+from mediapipe.python import packet_getter
+from mediapipe.python._framework_bindings import calculator_graph
+from mediapipe.python._framework_bindings import image_frame as image_frame_lib
+from mediapipe.python._framework_bindings import resource_util
+
+_BINARY_GRAPH_PATH = (
+    'mediapipe/modules/holistic_landmark/holistic_landmark_multi_cpu.binarypb'
+)
+_OUTPUT_STREAMS = (
+    'multi_pose_landmarks', 'multi_left_hand_landmarks',
+    'multi_right_hand_landmarks', 'multi_face_landmarks',
+)
+_MultiHolisticResults = collections.namedtuple(
+    'MultiHolisticResults',
+    ['pose_landmarks', 'left_hand_landmarks', 'right_hand_landmarks',
+     'face_landmarks'])
+
+
+class MultiHolistic:
+  """Runs MediaPipe Holistic for every person detected in an image."""
+
+  def __init__(self, model_complexity: int = 1,
+               refine_face_landmarks: bool = False):
+    """Initializes a MultiHolistic object.
+
+    Args:
+      model_complexity: Complexity of the pose landmark model: 0, 1 or 2.
+      refine_face_landmarks: Whether to refine face landmarks around the eyes
+        and lips and output additional iris landmarks.
+    """
+    root = os.sep.join(os.path.abspath(__file__).split(os.sep)[:-4])
+    resource_util.set_resource_dir(root)
+    self._graph = calculator_graph.CalculatorGraph(
+        binary_graph_path=os.path.join(root, _BINARY_GRAPH_PATH))
+    self._latest = {}
+    for stream in _OUTPUT_STREAMS:
+      self._graph.observe_output_stream(stream, self._make_callback(stream),
+                                        True)
+    self._graph.start_run({
+        'model_complexity': packet_creator.create_int(model_complexity),
+        'refine_face_landmarks':
+            packet_creator.create_bool(refine_face_landmarks),
+    })
+    self._timestamp = 0
+
+  def _make_callback(self, stream):
+    def callback(_, packet):
+      self._latest[stream] = packet
+    return callback
+
+  def _collect(self, stream) -> List[landmark_pb2.NormalizedLandmarkList]:
+    packet = self._latest.get(stream)
+    if packet is None or packet.is_empty():
+      return []
+    return list(packet_getter.get_proto_list(packet))
+
+  def process(self, image: np.ndarray) -> NamedTuple:
+    """Processes an RGB image; returns per-person landmark lists.
+
+    Args:
+      image: An RGB image represented as a numpy ndarray.
+
+    Returns:
+      A namedtuple with `pose_landmarks`, `left_hand_landmarks`,
+      `right_hand_landmarks` and `face_landmarks`, each a list of
+      `NormalizedLandmarkList` (one entry per detected person; hand/face entries
+      may be empty when not visible for that person).
+    """
+    self._latest.clear()
+    self._timestamp += 1
+    self._graph.add_packet_to_input_stream(
+        stream='image',
+        packet=packet_creator.create_image_frame(
+            image_frame_lib.ImageFrame(
+                image_format=image_frame_lib.ImageFormat.SRGB,
+                data=np.ascontiguousarray(image))),
+        timestamp=self._timestamp)
+    self._graph.wait_until_idle()
+    return _MultiHolisticResults(*[self._collect(s) for s in _OUTPUT_STREAMS])
+
+  def close(self) -> None:
+    self._graph.close()
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    self.close()


### PR DESCRIPTION
## Multi-person Holistic (graph-native)

`solutions.holistic.Holistic` is single-person: its `PoseLandmarkCpu` stage keeps
only the most prominent pose detection, so a frame with several people yields
pose + hands + face for just **one** of them. This PR adds multi-person Holistic
**inside the graph** — every detected person gets a full pose + hands + face
result.

### What's added

- **`HolisticBodyFromPoseCpu`** (`holistic_body_from_pose_cpu.pbtxt`) — the
  per-person hands + face portion of holistic, given that person's pose
  landmarks. It is **stateless**: unlike `HandLandmarksFromPoseCpu` /
  `FaceLandmarksFromPoseCpu` it drops the `HandTracking` / `FaceTracking`
  previous-frame back-edge, so it is safe to run inside a per-person loop (a
  per-frame back-edge inside a loop would leak state between people).
- **`HolisticLandmarkMultiCpu`** (`holistic_landmark_multi_cpu.pbtxt`) — replaces
  the single `PoseLandmarkCpu` with multi-person pose detection
  (`PoseDetectionCpu` → `ClipDetectionVectorSizeCalculator`) and a
  `BeginLoop`/`EndLoop` over detections that runs `PoseLandmarkByRoiCpu` +
  `HolisticBodyFromPoseCpu` per person. Outputs are vectors, one element per
  person.
- **`solutions.holistic_multi.MultiHolistic`** — Python wrapper returning a list
  of per-person `pose` / `left_hand` / `right_hand` / `face`
  `NormalizedLandmarkList`s.

### Pose detector threshold

`pose_detection_cpu.pbtxt`'s `min_score_thresh` is lowered `0.5 → 0.2`. The `0.5`
default is tuned to pick the *single* most-prominent person and suppresses
smaller / secondary people. The single-person `Pose` and `Holistic` solutions are
**unaffected** — they pass their own `min_detection_confidence` (default `0.5`)
as a calculator-param override.

### Usage

```python
import cv2, mediapipe as mp

mph = mp.solutions.holistic_multi.MultiHolistic(model_complexity=1)
image = cv2.cvtColor(cv2.imread('group.jpg'), cv2.COLOR_BGR2RGB)
result = mph.process(image)
for pose in result.pose_landmarks:          # one entry per detected person
    mp.solutions.drawing_utils.draw_landmarks(
        image, pose, mp.solutions.holistic.POSE_CONNECTIONS)
mph.close()
```

### Test procedure

```bash
# 1. Build the Python framework bindings (links the new graph) and a wheel,
#    or overlay the built _framework_bindings.so into an installed mediapipe.
bazel build -c opt --define MEDIAPIPE_DISABLE_GPU=1 \
    //mediapipe/python:_framework_bindings.so \
    //mediapipe/modules/holistic_landmark:holistic_landmark_multi_cpu

# 2. Get a 3-person video and extract 10 frames.
curl -sL -o people3.mp4 \
  https://www.sign-lang.uni-hamburg.de/meinedgs/videos/1413451-11105600-11163240/1413451-11105600-11163240_1c.mp4
python -c "import cv2; c=cv2.VideoCapture('people3.mp4'); [cv2.imwrite(f'f{i}.png', c.read()[1]) for i in range(10)]"
```

```python
import cv2, mediapipe as mp
mph = mp.solutions.holistic_multi.MultiHolistic()
for i in range(10):
    img = cv2.cvtColor(cv2.imread(f'f{i}.png'), cv2.COLOR_BGR2RGB)
    r = mph.process(img)
    print(i, 'people:', len(r.pose_landmarks))
mph.close()
```

### Results

On the 3-person video above, results are **consistently 3 people** — 3/3 with
pose + per-person hands on 9 of 10 frames (one frame finds 2 when the third
signer turns away). Per-frame counts:

| frame | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
|-------|---|---|---|---|---|---|---|---|---|---|
| people | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 2 |

The single-person `Holistic` solution was re-checked on a single-person crop and
is unchanged (pose + face landmarks as before).

### Scope / notes

- People are detected **every frame** (the BlazePose detector is multi-person via
  NMS). Cross-frame ROI association (as in `hand_landmark_tracking_cpu`) is
  intentionally **not** used: pose ROIs are square and full-body-sized, so people
  standing apart in a wide frame still produce heavily-overlapping ROIs that
  ROI-IoU association would wrongly merge into one. Per-frame detection keeps each
  person distinct.
- Faces of small/distant people are detected only intermittently — a limitation
  of the face detector on tiny faces, not of the wiring (face landmarks are
  produced correctly when the face is large enough).