### PR TITLE
Fix arbitrary out-of-bounds write (write-what-where) in MaxUnpooling2D

### DIFF
--- a/mediapipe/util/tflite/operations/max_unpooling.cc
+++ b/mediapipe/util/tflite/operations/max_unpooling.cc
@@ -37,6 +37,8 @@ inline void MaxUnpooling(const ::tflite::PoolParams& params,
   const int depth = MatchingDim(input_shape, 3, output_shape, 3);
   const int input_height = input_shape.Dims(1);
   const int input_width = input_shape.Dims(2);
+  const int output_height = output_shape.Dims(1);
+  const int output_width = output_shape.Dims(2);
   const int stride_height = params.stride_height;
   const int stride_width = params.stride_width;
   std::memset(output_data, 0, output_shape.FlatSize() * sizeof(float));
@@ -53,8 +55,16 @@ inline void MaxUnpooling(const ::tflite::PoolParams& params,
               in_x * stride_width - params.padding_values.width + max_x;
           const int out_y =
               in_y * stride_height - params.padding_values.height + max_y;
-          output_data[Offset(output_shape, batch, out_y, out_x, channel)] =
-              input_data[input_offset];
+          // The index comes from the (potentially untrusted) `indices` tensor,
+          // so the destination it decodes to must be validated against the
+          // output bounds before writing. An out-of-range index does not
+          // describe a legitimate unpooling location; skipping it prevents an
+          // out-of-bounds write (CWE-787).
+          if (out_x >= 0 && out_x < output_width && out_y >= 0 &&
+              out_y < output_height) {
+            output_data[Offset(output_shape, batch, out_y, out_x, channel)] =
+                input_data[input_offset];
+          }
         }
       }
     }


### PR DESCRIPTION
The `MaxUnpooling2D` custom op performs an unchecked, attacker-controlled memory write while running a `.tflite` model, and I believe it is a likely path to remote code execution. It was reported to Google, who triaged it and closed it as "Won't fix (Intended behavior)." I disagree, and I'm submitting the patch so that consumers relying on the default op resolver aren't left exposed — an out-of-range unpooling index does not describe any legitimate model, it can only corrupt memory.

The problem lives in the `MaxUnpooling` helper in `mediapipe/util/tflite/operations/max_unpooling.cc`, reached from `Eval`. For each input element the op writes the value back to the output at the location recorded in the `indices` tensor. It reads that index, decodes it into an `out_x`/`out_y` destination, and stores straight into `output_data` at that offset with no bounds check on the destination. The index comes straight from the `indices` tensor, and in a malicious `.tflite` that tensor is a constant whose bytes the attacker chooses. So the index drives `out_x`/`out_y`, and the store degenerates into `output[attacker_offset] = attacker_value` — a fully controlled out-of-bounds write. This isn't intended behavior, it's a dropped check: the sibling op in this very directory, `transpose_conv_bias.cc`, already guards the identical write pattern by requiring `out_x` and `out_y` to fall within the output width and height before writing. `MaxUnpooling2D` is simply missing that guard.

And it's reachable zero-click, because the default `MediaPipeBuiltinOpResolver` registers this op unconditionally via `AddCustom("MaxUnpooling2D", RegisterMaxUnpooling2D())`. Any consumer that loads an untrusted or auto-updated model with the default resolver is exposed — there's no runtime input and no driver interaction required, the file does everything.

It's worth being precise about why this rises to RCE rather than "just" memory corruption. Because the primitive is a fully controlled write-what-where — both the destination and the written value are attacker-controlled — it can overwrite a live code pointer, specifically the `invoke` callback of an operator's `TfLiteRegistration` in the interpreter's node-and-registration table. The interpreter runs each operator by making an indirect call through that `invoke` pointer, so once it holds an attacker-chosen address, the next dispatch of that operator transfers execution to attacker-controlled code — a control-flow hijack, i.e. remote code execution. Concretely you can do this from a static file with a two-op graph where every tensor is a baked-in constant: a first `MaxUnpooling2D` feeds an intermediate tensor into a second `MaxUnpooling2D`. Op #0's unchecked constant index writes the constant value into the intermediate tensor at the attacker-chosen offset, calibrated so the store lands on op #1's live `invoke` pointer and overwrites it; the interpreter then dispatches op #1 and jumps to the attacker-chosen address. No runtime input, no driver interaction.

The fix is to validate the decoded destination against the output tensor's dimensions before writing, exactly the way the sibling op already does. Since `batch` and `channel` are already loop-bounded, constraining `out_x`/`out_y` to the output width and height guarantees the flat offset stays within bounds, so no index the model supplies can steer the write outside the output tensor.

On disclosure: this was reported to Google through their private vulnerability program and closed as "Won't fix (Intended behavior)." In that same response they added: "You're definitely welcome to open an issue or submit a pull request directly on the MediaPipe GitHub repository to help get this fixed." This PR is that fix, published so that consumers relying on the default op resolver can protect themselves.
