### PR TITLE
Expose CPU inference thread count via BaseOptions.num_threads

### DIFF
--- a/mediapipe/tasks/c/core/base_options.h
+++ b/mediapipe/tasks/c/core/base_options.h
@@ -63,6 +63,10 @@ struct MpBaseOptions {
   // The delegate to use for the MediaPipe graph.
   enum MpDelegate delegate;
 
+  // Number of CPU threads for inference (XNNPACK). If <= 0, the framework
+  // default is used. Only applies when `delegate` is CPU.
+  int num_threads;
+
   // The environment on which the task is running.
   enum MpHostEnvironment host_environment;
 

--- a/mediapipe/tasks/c/core/base_options_converter.cc
+++ b/mediapipe/tasks/c/core/base_options_converter.cc
@@ -85,6 +85,7 @@ void CppConvertToBaseOptions(const MpBaseOptions& in,
   out->model_asset_path =
       in.model_asset_path ? std::string(in.model_asset_path) : "";
   out->delegate = CppConvertToDelegate(in.delegate);
+  out->num_threads = in.num_threads;
   out->host_environment = CppConvertToHostEnvironment(in.host_environment);
   out->host_system = CppConvertToHostSystem(in.host_system);
   out->host_version = in.host_version ? std::string(in.host_version) : "";

--- a/mediapipe/tasks/cc/core/base_options.cc
+++ b/mediapipe/tasks/cc/core/base_options.cc
@@ -100,7 +100,15 @@ proto::BaseOptions ConvertBaseOptionsToProto(BaseOptions* base_options) {
   }
   switch (base_options->delegate) {
     case BaseOptions::Delegate::CPU:
-      base_options_proto.mutable_acceleration()->mutable_tflite();
+      if (base_options->num_threads > 0) {
+        // Use the XNNPACK delegate so the requested thread count is honored; an
+        // empty TfLite delegate defaults to single-threaded inference.
+        base_options_proto.mutable_acceleration()
+            ->mutable_xnnpack()
+            ->set_num_threads(base_options->num_threads);
+      } else {
+        base_options_proto.mutable_acceleration()->mutable_tflite();
+      }
       SetDelegateOptionsOrDie<BaseOptions::CpuOptions>(base_options,
                                                        base_options_proto);
       break;

--- a/mediapipe/tasks/cc/core/base_options.h
+++ b/mediapipe/tasks/cc/core/base_options.h
@@ -52,6 +52,10 @@ struct BaseOptions {
 
   Delegate delegate = CPU;
 
+  // Number of CPU threads used for inference (XNNPACK). If <= 0, MediaPipe's
+  // framework default is used. Only applies when `delegate` is CPU.
+  int num_threads = -1;
+
   // Options for CPU.
   struct CpuOptions {};
 

--- a/mediapipe/tasks/cc/core/base_options_test.cc
+++ b/mediapipe/tasks/cc/core/base_options_test.cc
@@ -46,6 +46,26 @@ TEST(BaseOptionsTest, ConvertBaseOptionsToProtoWithAcceleration) {
   EXPECT_EQ(proto.acceleration().nnapi().accelerator_name(), "google-edgetpu");
 }
 
+TEST(BaseOptionsTest, ConvertBaseOptionsToProtoWithCpuNumThreads) {
+  BaseOptions base_options;
+  base_options.delegate = BaseOptions::Delegate::CPU;
+  base_options.num_threads = 4;
+  proto::BaseOptions proto = ConvertBaseOptionsToProto(&base_options);
+  ASSERT_TRUE(proto.acceleration().has_xnnpack());
+  EXPECT_EQ(proto.acceleration().xnnpack().num_threads(), 4);
+  EXPECT_FALSE(proto.acceleration().has_tflite());
+}
+
+TEST(BaseOptionsTest, ConvertBaseOptionsToProtoWithDefaultNumThreadsUsesTfLite) {
+  BaseOptions base_options;
+  base_options.delegate = BaseOptions::Delegate::CPU;
+  // num_threads defaults to -1, which must keep the existing behavior of an
+  // empty TfLite delegate (no explicit XNNPACK thread count).
+  proto::BaseOptions proto = ConvertBaseOptionsToProto(&base_options);
+  EXPECT_TRUE(proto.acceleration().has_tflite());
+  EXPECT_FALSE(proto.acceleration().has_xnnpack());
+}
+
 TEST(DelegateOptionsTest, SucceedCpuOptions) {
   BaseOptions base_options;
   base_options.delegate = BaseOptions::Delegate::CPU;

--- a/mediapipe/tasks/python/core/base_options.py
+++ b/mediapipe/tasks/python/core/base_options.py
@@ -74,6 +74,9 @@ class BaseOptions:
     model_asset_buffer: The model asset file contents as bytes.
     delegate: Acceleration to use. Supported values are GPU and CPU. GPU support
       is currently limited to Ubuntu platforms.
+    num_threads: Number of CPU threads to use for inference (XNNPACK delegate).
+      If unset or <= 0, MediaPipe's framework default is used. Only applies when
+      `delegate` is CPU.
   """
 
   class Delegate(enum.IntEnum):
@@ -83,6 +86,7 @@ class BaseOptions:
   model_asset_path: Optional[str] = None
   model_asset_buffer: Optional[bytes] = None
   delegate: Optional[Delegate] = None
+  num_threads: Optional[int] = None
 
   @doc_controls.do_not_generate_docs
   def to_ctypes(self) -> base_options_c_lib.MpBaseOptionsC:
@@ -100,6 +104,9 @@ class BaseOptions:
         self.model_asset_path.encode('utf-8') if self.model_asset_path else None
     )
     options.delegate = self.delegate.value if self.delegate else 0
+    options.num_threads = (
+        self.num_threads if self.num_threads is not None else -1
+    )
     options.host_environment = HOST_ENVIRONMENT_PYTHON
     host_version, *_ = sys.version.split(' ')
     options.host_system = host_system
@@ -125,4 +132,5 @@ class BaseOptions:
         self.model_asset_path == other.model_asset_path
         and self.model_asset_buffer == other.model_asset_buffer
         and self.delegate == other.delegate
+        and self.num_threads == other.num_threads
     )

--- a/mediapipe/tasks/python/core/base_options_c.py
+++ b/mediapipe/tasks/python/core/base_options_c.py
@@ -26,6 +26,7 @@ class MpBaseOptionsC(ctypes.Structure):
     model_asset_path: `bytes`, the path to the model asset.
     file_descriptor: `int`, the file descriptor of the model asset.
     delegate: `int`, the delegate to use.
+    num_threads: `int`, number of CPU inference threads (<= 0 uses the default).
     host_environment: `int`, the environment in which the task is running.
     host_system: `int`, the system on which the task is running.
     host_version: `bytes`, the Python version as a UTF-8 string.
@@ -40,6 +41,7 @@ class MpBaseOptionsC(ctypes.Structure):
       ("model_asset_path", ctypes.c_char_p),
       ("file_descriptor", ctypes.c_int),
       ("delegate", ctypes.c_int),
+      ("num_threads", ctypes.c_int),
       ("host_environment", ctypes.c_int),
       ("host_system", ctypes.c_int),
       ("host_version", ctypes.c_char_p),


### PR DESCRIPTION
Close #3644 #6151

## Description:
MediaPipe Tasks CPU inference runs single-threaded on non-mobile platforms with no way to change it from the public API. This adds a num_threads field to BaseOptions across the Python, C, and C++ layers. When set (> 0) with the CPU delegate, it emits an XNNPACK delegate with that thread count; unset keeps the current single-threaded default, so existing behavior is unchanged.

## Changed
base_options.py, base_options_c.py, c/core/base_options.h, base_options_converter.cc, cc/core/base_options.h, base_options.cc, and base_options_test.cc (unit tests for the new field).

## Testing:
Base_options_test passes; a real-model run confirmed output is bit-identical across 1/2/4 threads.

## Related issues:
- #6151 (Add a method to set the number of threads) — this PR implements that request by adding the num_threads option.
- #3644 (How to set xnnpack num_threads in Python) — the C++ xnnpack { num_threads } knob existed but wasn't reachable from the Tasks API; this PR surfaces it through BaseOptions.