### PR TITLE
Fix IOSurface leak causing macOS GPU pipelines to abort

### DIFF
--- a/mediapipe/gpu/gpu_buffer_storage_cv_pixel_buffer.cc
+++ b/mediapipe/gpu/gpu_buffer_storage_cv_pixel_buffer.cc
@@ -33,6 +33,7 @@ GlTextureView GpuBufferStorageCvPixelBuffer::GetTexture(
   auto gl_context = GlContext::GetCurrent();
   ABSL_CHECK(gl_context);
 #if TARGET_OS_OSX
+  CVOpenGLTextureCacheFlush(gl_context->cv_texture_cache(), 0);
   CVTextureType cv_texture_temp;
   err = CVOpenGLTextureCacheCreateTextureFromImage(
       kCFAllocatorDefault, gl_context->cv_texture_cache(), **this, NULL,


### PR DESCRIPTION
### Problem

GPU pipelines on macOS abort after a few minutes of continuous inference. `CVPixelBufferCreate` fails with -6662 (`kCVReturnAllocationFailed`) in `CreateCVPixelBufferWithoutPool`, and the `ABSL_CHECK_OK` in `ConvertFromImageFrame` turns that into an abort.

This was reported in #5267 from Python with the pose landmarker in live stream mode, where the reporter also confirmed that CPU mode ran for 72 hours without a problem. That issue was closed by the stale bot, not fixed.

### Cause

Unlike `CVOpenGLESTextureCache`, `CVOpenGLTextureCache` does not recycle unused entries when a texture is created. The only flush during a session is in `CvPixelBufferPoolWrapper::GetBuffer`, which runs when the pool exceeds its allocation threshold. Pixel buffers created outside the pool, such as those from the `ImageFrame` -> `GpuBufferStorageCvPixelBuffer` converter, never reach it, so every frame leaks a cached texture and its backing IOSurface until allocation fails.

### Fix

Flush the texture cache before creating a texture on macOS. `CVOpenGLTextureCacheFlush` releases only entries whose `CVOpenGLTextureRef` is already released, so in-flight `GlTextureView`s are unaffected.

### Verification

Hand landmarker in video mode with the GPU delegate, 1280x720, M1 Max / macOS 26.5.2, 1200 frames after 60 warmup frames. Two macOS static libraries were built from the same tree, one with and one without this change, and the two runs were alternated twice:

| | mean | p95 | process footprint |
|---|---|---|---|
| before | 11.8 to 12.3 ms | 16.5 to 17.3 ms | grows linearly, 10.6 MB per frame |
| after | 8.8 to 9.1 ms | 11.6 to 11.8 ms | bounded, no trend |

Before the change the footprint grows by 3189 MB at 300 frames, 6378 MB at 600, 9567 MB at 900 and 12755 MB at 1200, which is about three 1280x720 buffers per frame. After the change it oscillates within a few hundred MB and stays flat. Latency improves rather than regresses, since the flush costs less than backing new surfaces every frame.

In a real application doing continuous hand tracking on a camera stream, the same build without this change aborted 11 minutes after launch (crash report below). With the change it has run for over 30 minutes of continuous tracking without aborting.

This addresses the allocation failure only. The `unsupported ImageFrame format` failure reported later in #5267 hits the same check for a different reason and is not covered here.

<details>
<summary>Crash report from the aborting run (application name, identifiers, and application frames redacted)</summary>

```
Process:             <redacted>
Path:                /Applications/<redacted>.app/Contents/MacOS/<redacted>
Identifier:          <redacted>
Code Type:           ARM-64 (Native)
Parent Process:      launchd [1]

Date/Time:           2026-08-10 21:45:05.2339 +0900
Launch Time:         2026-08-10 21:33:37.6249 +0900
Hardware Model:      MacBookPro18,4
OS Version:          macOS 26.5.2 (25F84)

Exception Type:    EXC_CRASH (SIGABRT)
Exception Codes:   0x0000000000000000, 0x0000000000000000
Termination Reason:  Namespace SIGNAL, Code 6, Abort trap: 6

Application Specific Information:
abort() called

Thread 62 Crashed:: */0
0   libsystem_kernel.dylib        	       0x1893325e8 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x18936d8d8 pthread_kill + 296
2   libsystem_c.dylib             	       0x1892746e8 __abort + 152
3   libsystem_c.dylib             	       0x189274650 abort + 160
4   MediaPipeTasksVision          	       0x13c827e60 absl::lts_20260107::log_internal::LogMessage::FailWithoutStackTrace() + 20
5   MediaPipeTasksVision          	       0x13b5faccc absl::lts_20260107::log_internal::LogMessage::SendToLog() + 148
6   MediaPipeTasksVision          	       0x13b5fac08 absl::lts_20260107::log_internal::LogMessage::Flush() + 332
7   MediaPipeTasksVision          	       0x13bff923c mediapipe::ConvertFromImageFrame(std::__1::shared_ptr<mediapipe::GpuBufferStorageImageFrame>) + 264
8   MediaPipeTasksVision          	       0x13bff9a44 [GpuBufferStorageRegistry::RegisterConverter converter thunk, template arguments elided]
9   MediaPipeTasksVision          	       0x13bffe58c [std::__1::__function::__func<...> thunk, template arguments elided]
10  MediaPipeTasksVision          	       0x13bffd538 mediapipe::GpuBuffer::StorageHolder::GetStorageForView(mediapipe::TypeId, bool) const + 536
11  MediaPipeTasksVision          	       0x13bffddb8 mediapipe::GpuBuffer::GetStorageForViewOrDie(mediapipe::TypeId, bool) const + 36
12  MediaPipeTasksVision          	       0x13bf1ea94 mediapipe::Image::ConvertToGpu() const + 56
13  MediaPipeTasksVision          	       0x13be443a4 [GlCalculatorHelper::RunInGlContext<ImageCloneCalculator::Process lambda> thunk]
14  MediaPipeTasksVision          	       0x13bfeb78c mediapipe::GlContext::SwitchContextAndRun(std::__1::function<absl::lts_20260107::Status ()>) + 120
15  MediaPipeTasksVision          	       0x13bfeb1f4 mediapipe::GlContext::Run(std::__1::function<absl::lts_20260107::Status ()>, int, mediapipe::Timestamp) + 984
16  MediaPipeTasksVision          	       0x13bfe6264 mediapipe::GlCalculatorHelper::RunInGlContext(std::__1::function<absl::lts_20260107::Status ()>, mediapipe::CalculatorContext*) + 208
17  MediaPipeTasksVision          	       0x13bfe6430 mediapipe::GlCalculatorHelper::RunInGlContext(std::__1::function<absl::lts_20260107::Status ()>) + 208
18  MediaPipeTasksVision          	       0x13be439cc void mediapipe::GlCalculatorHelper::RunInGlContext<mediapipe::api2::ImageCloneCalculator::Process(mediapipe::CalculatorContext*)::'lambda'(), void>(...) + 68
19  MediaPipeTasksVision          	       0x13be4316c mediapipe::api2::ImageCloneCalculator::Process(mediapipe::CalculatorContext*) + 1472
20  MediaPipeTasksVision          	       0x13bf4e458 mediapipe::CalculatorNode::ProcessNode(mediapipe::CalculatorContext*) + 844
21  MediaPipeTasksVision          	       0x13bf7d9d4 mediapipe::internal::SchedulerQueue::RunCalculatorNode(mediapipe::CalculatorNode*, mediapipe::CalculatorContext*) + 368
22  MediaPipeTasksVision          	       0x13bf7d3d0 mediapipe::internal::SchedulerQueue::RunNextTask() + 128
23  MediaPipeTasksVision          	       0x13bf141f4 mediapipe::ThreadPool::RunWorker() + 344
24  MediaPipeTasksVision          	       0x13bf13d44 mediapipe::ThreadPool::WorkerThread::ThreadBody(void*) + 296
25  libsystem_pthread.dylib       	       0x18936dc58 _pthread_start + 136
26  libsystem_pthread.dylib       	       0x189368c1c thread_start + 8

Thread 93::  Dispatch queue: com.apple.root.user-initiated-qos.cooperative
0   libsystem_kernel.dylib        	       0x18932d50c __psynch_cvwait + 8
1   libsystem_pthread.dylib       	       0x18936e128 _pthread_cond_wait + 980
2   MediaPipeTasksVision          	       0x13b631124 absl::lts_20260107::synchronization_internal::PthreadWaiter::Wait(absl::lts_20260107::synchronization_internal::KernelTimeout) + 168
3   MediaPipeTasksVision          	       0x13b630f58 AbslInternalPerThreadSemWait_lts_20260107 + 76
4   MediaPipeTasksVision          	       0x13c82bde0 absl::lts_20260107::CondVar::WaitCommon(absl::lts_20260107::Mutex*, absl::lts_20260107::synchronization_internal::KernelTimeout) + 188
5   MediaPipeTasksVision          	       0x13bf46d30 mediapipe::internal::Scheduler::ApplicationThreadAwait(std::__1::function<bool ()> const&) + 84
6   MediaPipeTasksVision          	       0x13bf4710c mediapipe::internal::Scheduler::WaitUntilIdle() + 112
7   MediaPipeTasksVision          	       0x13bf3d760 mediapipe::CalculatorGraph::WaitUntilIdle() + 72
8   MediaPipeTasksVision          	       0x13c044884 mediapipe::tasks::core::TaskRunner::Process(std::__1::map<...>) + 892
9   MediaPipeTasksVision          	       0x13c0e3e00 -[MPPTaskRunner processPacketMap:error:] + 60
10  MediaPipeTasksVision          	       0x13c0e7d68 -[MPPVisionTaskRunner processVideoFrame:regionOfInterest:timestampInMilliseconds:error:] + 164
11  MediaPipeTasksVision          	       0x13c112d9c -[MPPHandLandmarker detectVideoFrame:timestampInMilliseconds:error:] + 72
12+ [application frames elided]
```

</details>