### PR TITLE
Fix browser script load error rejection

### DIFF
--- a/mediapipe/web/graph_runner/BUILD
+++ b/mediapipe/web/graph_runner/BUILD
@@ -120,6 +120,18 @@ ts_library(
     srcs = ["run_script_helper.ts"],
 )
 
+ts_library(
+    name = "run_script_helper_test_lib",
+    testonly = True,
+    srcs = ["run_script_helper.test.ts"],
+    deps = [":run_script_helper"],
+)
+
+jasmine_node_test(
+    name = "run_script_helper_test",
+    srcs = [":run_script_helper_test_lib"],
+)
+
 jasmine_node_test(
     name = "platform_utils_test",
     srcs = [

--- a/mediapipe/web/graph_runner/run_script_helper.test.ts
+++ b/mediapipe/web/graph_runner/run_script_helper.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 The MediaPipe Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jasmine';
+
+import {runScript} from '../../web/graph_runner/run_script_helper';
+
+describe('runScript()', () => {
+  const globalDocument =
+      Object.getOwnPropertyDescriptor(globalThis, 'document');
+
+  afterEach(() => {
+    if (globalDocument) {
+      Object.defineProperty(globalThis, 'document', globalDocument);
+    } else {
+      delete (globalThis as {document?: Document}).document;
+    }
+  });
+
+  it('rejects with an Error when a script fails to load', async () => {
+    const scriptUrl = 'https://example.com/vision_wasm_internal.js';
+    const loadEvent = {type: 'error'} as Event;
+    let errorListener: EventListener|undefined;
+    const script = {
+      addEventListener: (type: string, listener: EventListener) => {
+        if (type === 'error') {
+          errorListener = listener;
+        }
+      },
+      crossOrigin: '',
+      src: '',
+    } as HTMLScriptElement;
+    const documentMock = {
+      body: {
+        appendChild: () => {
+          errorListener?.(loadEvent);
+        },
+      },
+      createElement: () => script,
+    } as unknown as Document;
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: documentMock,
+    });
+
+    try {
+      await runScript(scriptUrl);
+      fail('Expected runScript() to reject.');
+    } catch (error) {
+      expect(error).toEqual(jasmine.any(Error));
+      expect((error as Error).message).toContain(scriptUrl);
+      expect((error as Error&{cause: unknown}).cause).toBe(loadEvent);
+    }
+  });
+});

--- a/mediapipe/web/graph_runner/run_script_helper.ts.template
+++ b/mediapipe/web/graph_runner/run_script_helper.ts.template
@@ -33,12 +33,21 @@ export async function runScript(scriptUrl: string) {
     const script = document.createElement('script');
     (script as {src:string}).src = scriptUrl.toString();
     script.crossOrigin = 'anonymous';
-    return new Promise<void>((resolve, revoke) => {
+    return new Promise<void>((resolve, reject) => {
       script.addEventListener('load', () => {
         resolve();
       }, false);
       script.addEventListener('error', e => {
-        revoke(e);
+        const error =
+            new Error('Failed to load script: ' + scriptUrl.toString());
+        // ErrorOptions.cause is not in the ES2021 type library used here, so
+        // define it explicitly while preserving the standard property shape.
+        Object.defineProperty(error, 'cause', {
+          configurable: true,
+          value: e,
+          writable: true,
+        });
+        reject(error);
       }, false);
       document.body.appendChild(script);
     });


### PR DESCRIPTION
## What changed

- Reject browser script load failures with an `Error` instead of the raw DOM `Event`.
- Include the failed script URL in the error message.
- Preserve the original load event as `error.cause`.
- Add focused regression coverage for the rejection shape.

## Why

When a MediaPipe WASM loader script fails to load, the browser dispatches a plain `Event`. The current error listener passes that event directly to the Promise rejection. Callers therefore receive a non-`Error` value with no useful message or stack, which obscures both the failed asset and where the load originated.

The original callback also named the Promise rejection function `revoke`, making the intended behavior less clear.

## Impact

This changes only the browser `<script>` loading failure path. Successful loads and worker `importScripts()` behavior are unchanged. Existing catch blocks continue to receive a rejection, now with a conventional `Error` value and richer diagnostic context.

The project targets the ES2021 type library, which predates `ErrorOptions`. The implementation therefore defines the standard `cause` property explicitly instead of using the newer two-argument `Error` constructor.

## Checks

- TypeScript 5.3.3 strict compile of the helper and test: passed
- Jasmine regression test: passed (1 spec)
- Buildifier check for `mediapipe/web/graph_runner/BUILD`: passed
- `git diff --check`: passed
- `bazelisk test //mediapipe/web/graph_runner:run_script_helper_test`: blocked during target analysis by the current upstream `rules_java` module resolving `@rules_java~//tools/jdk` without a BUILD file; no changed source was compiled before this failure
