### PR TITLE
Bounds-check zip entry position/size in ExtractFilesfromZipFile

### DIFF
--- a/mediapipe/tasks/cc/metadata/utils/zip_utils.cc
+++ b/mediapipe/tasks/cc/metadata/utils/zip_utils.cc
@@ -142,6 +142,18 @@ absl::Status ExtractFilesfromZipFile(
     int error = unzGoToFirstFile(zf);
     while (error == UNZ_OK) {
       ABSL_ASSIGN_OR_RETURN(auto zip_file_info, GetCurrentZipFileInfo(zf));
+      // Validate that the entry's position and size stay within the model
+      // buffer before constructing a string_view into it. `position` and `size`
+      // originate from the (untrusted) zip central directory and are otherwise
+      // unchecked, so a crafted archive could otherwise yield an out-of-bounds
+      // read. Written to avoid unsigned overflow.
+      if (zip_file_info.position > buffer_size ||
+          zip_file_info.size > buffer_size - zip_file_info.position) {
+        return CreateStatusWithPayload(
+            StatusCode::kInvalidArgument,
+            "Zip archive entry extends beyond the model buffer.",
+            MediaPipeTasksStatus::kFileZipError);
+      }
       // Store result in map.
       (*files)[zip_file_info.name] = absl::string_view(
           buffer_data + zip_file_info.position, zip_file_info.size);


### PR DESCRIPTION
### Summary
`ExtractFilesfromZipFile` builds an `absl::string_view` directly into the model buffer using
`zip_file_info.position` and `zip_file_info.size`, both of which come from the zip central
directory (`uncompressed_size` / stream position) and are never validated against `buffer_size`.
A crafted `.task`/model bundle can therefore point an entry past the end of the buffer, producing a
heap out-of-bounds read when the referenced bytes are later consumed.

This adds an overflow-safe bounds check before constructing the `string_view`.

### Impact
Out-of-bounds read (crash / potential info disclosure) when loading a crafted model bundle via the
Tasks API (e.g. `BaseOptions(model_asset_path=...)`), before inference.

### Change
Reject any entry where `position > buffer_size` or `size > buffer_size - position`. No behavior
change for valid archives.

### Notes
Reported through the Google OSS VRP (issue 546472889). Verified with an AddressSanitizer PoC against
this code path. Analysis was AI-assisted and human-reviewed; I was not able to run the full Bazel
build locally, so please run CI.
