### PR TITLE
Validate metadata buffer index and subgraph_metadata size in ModelMetadataExtractor

### DIFF
--- a/mediapipe/tasks/cc/metadata/metadata_extractor.cc
+++ b/mediapipe/tasks/cc/metadata/metadata_extractor.cc
@@ -144,8 +144,22 @@ absl::Status ModelMetadataExtractor::InitFromModelBuffer(
       continue;
     }
     const auto buffer_index = metadata->buffer();
-    const auto metadata_buffer =
-        model_->buffers()->Get(buffer_index)->data()->data();
+    if (model_->buffers() == nullptr ||
+        buffer_index >= model_->buffers()->size()) {
+      return CreateStatusWithPayload(
+          StatusCode::kInvalidArgument,
+          "Metadata refers to an out-of-range buffer index.",
+          MediaPipeTasksStatus::kMetadataInvalidSchemaVersionError);
+    }
+    const auto* metadata_buffer_table = model_->buffers()->Get(buffer_index);
+    if (metadata_buffer_table == nullptr ||
+        metadata_buffer_table->data() == nullptr) {
+      return CreateStatusWithPayload(
+          StatusCode::kInvalidArgument,
+          "Metadata buffer has no data.",
+          MediaPipeTasksStatus::kMetadataInvalidSchemaVersionError);
+    }
+    const auto metadata_buffer = metadata_buffer_table->data()->data();
     if (!tflite::ModelMetadataBufferHasIdentifier(metadata_buffer)) {
       return CreateStatusWithPayload(
           StatusCode::kInvalidArgument,
@@ -228,7 +242,8 @@ absl::StatusOr<std::string> ModelMetadataExtractor::GetModelVersion() const {
 const flatbuffers::Vector<flatbuffers::Offset<tflite::TensorMetadata>>*
 ModelMetadataExtractor::GetInputTensorMetadata() const {
   if (model_metadata_ == nullptr ||
-      model_metadata_->subgraph_metadata() == nullptr) {
+      model_metadata_->subgraph_metadata() == nullptr ||
+      model_metadata_->subgraph_metadata()->size() <= kDefaultSubgraphIndex) {
     return nullptr;
   }
   return model_metadata_->subgraph_metadata()
@@ -251,7 +266,8 @@ int ModelMetadataExtractor::GetInputTensorCount() const {
 const Vector<Offset<TensorMetadata>>*
 ModelMetadataExtractor::GetOutputTensorMetadata() const {
   if (model_metadata_ == nullptr ||
-      model_metadata_->subgraph_metadata() == nullptr) {
+      model_metadata_->subgraph_metadata() == nullptr ||
+      model_metadata_->subgraph_metadata()->size() <= kDefaultSubgraphIndex) {
     return nullptr;
   }
   return model_metadata_->subgraph_metadata()
@@ -274,7 +290,8 @@ int ModelMetadataExtractor::GetOutputTensorCount() const {
 const Vector<flatbuffers::Offset<tflite::ProcessUnit>>*
 ModelMetadataExtractor::GetInputProcessUnits() const {
   if (model_metadata_ == nullptr ||
-      model_metadata_->subgraph_metadata() == nullptr) {
+      model_metadata_->subgraph_metadata() == nullptr ||
+      model_metadata_->subgraph_metadata()->size() <= kDefaultSubgraphIndex) {
     return nullptr;
   }
   return model_metadata_->subgraph_metadata()
@@ -296,7 +313,8 @@ int ModelMetadataExtractor::GetInputProcessUnitsCount() const {
 const Vector<flatbuffers::Offset<tflite::ProcessUnit>>*
 ModelMetadataExtractor::GetOutputProcessUnits() const {
   if (model_metadata_ == nullptr ||
-      model_metadata_->subgraph_metadata() == nullptr) {
+      model_metadata_->subgraph_metadata() == nullptr ||
+      model_metadata_->subgraph_metadata()->size() <= kDefaultSubgraphIndex) {
     return nullptr;
   }
   return model_metadata_->subgraph_metadata()
@@ -318,7 +336,8 @@ int ModelMetadataExtractor::GetOutputProcessUnitsCount() const {
 const flatbuffers::Vector<flatbuffers::Offset<tflite::CustomMetadata>>*
 ModelMetadataExtractor::GetCustomMetadataList() const {
   if (model_metadata_ == nullptr ||
-      model_metadata_->subgraph_metadata() == nullptr) {
+      model_metadata_->subgraph_metadata() == nullptr ||
+      model_metadata_->subgraph_metadata()->size() <= kDefaultSubgraphIndex) {
     return nullptr;
   }
   return model_metadata_->subgraph_metadata()


### PR DESCRIPTION
### Summary
Two hardening fixes in `ModelMetadataExtractor`:

1. **Unchecked metadata buffer index / null data.** `InitFromModelBuffer` uses
   `metadata->buffer()` directly as `model_->buffers()->Get(buffer_index)->data()->data()`. The index
   comes from the (untrusted) model flatbuffer and is not bounds-checked against `buffers()->size()`,
   and the `Buffer.data` field is optional and not null-checked. `VerifyModelBuffer` validates
   structure but not this semantic cross-reference, so a crafted model yields an out-of-bounds read /
   null dereference.

2. **`subgraph_metadata()->Get(0)` on an empty vector.** The five subgraph accessors
   (`GetInputTensorMetadata`, `GetOutputTensorMetadata`, `GetInputProcessUnits`,
   `GetOutputProcessUnits`, `GetCustomMetadataList`) null-check `subgraph_metadata()` but never check
   `size() > 0` before `Get(kDefaultSubgraphIndex)`. An empty (yet perfectly valid) `subgraph_metadata`
   vector passes `VerifyModelMetadataBuffer` and then triggers an out-of-bounds read in
   `Vector::Get(0)` in release builds. `metadata_version.cc` already guards this same field with a
   size check; these accessors did not.

### Impact
Out-of-bounds read (crash / potential info disclosure) when loading a crafted — or, for (2), a fully
valid but empty-subgraph — model via essentially any Tasks `Create()` (classifiers, detector,
embedders), before inference.

### Change
Bounds-check the buffer index and null-check `data()`; add `size() > kDefaultSubgraphIndex` to the
five accessors. No behavior change for valid models with populated metadata.

### Notes
Reported through the Google OSS VRP (issue 546472889). Both issues verified with AddressSanitizer PoCs.
Analysis was AI-assisted and human-reviewed; I could not run the full Bazel build locally, so please
run CI.
