### PR TITLE
Verify untrusted embedded flatbuffer/flexbuffer before parsing in detection_postprocessing_graph

### DIFF
--- a/mediapipe/tasks/cc/components/processors/detection_postprocessing_graph.cc
+++ b/mediapipe/tasks/cc/components/processors/detection_postprocessing_graph.cc
@@ -397,6 +397,7 @@ int GetMaxClassesPerDetection(const tflite::Model& model) {
       model.operator_codes()->begin(), model.operator_codes()->end(),
       [](const auto& op_code) {
         return op_code->builtin_code() == tflite::BuiltinOperator_CUSTOM &&
+               op_code->custom_code() != nullptr &&
                op_code->custom_code()->str() == kDetectionPostProcessOpName;
       });
   if (op_code_it == model.operator_codes()->end()) {
@@ -410,12 +411,20 @@ int GetMaxClassesPerDetection(const tflite::Model& model) {
                    [detection_opcode_index](const auto& op) {
                      return op->opcode_index() == detection_opcode_index;
                    });
-  if (detection_op_it != operators.end()) {
-    auto op_config =
-        flexbuffers::GetRoot(detection_op_it->custom_options()->Data(),
-                             detection_op_it->custom_options()->size())
-            .AsMap();
-    return op_config["max_classes_per_detection"].AsInt32();
+  if (detection_op_it != operators.end() &&
+      detection_op_it->custom_options() != nullptr) {
+    const uint8_t* custom_options_data =
+        detection_op_it->custom_options()->Data();
+    const size_t custom_options_size =
+        detection_op_it->custom_options()->size();
+    // Verify the (untrusted) flexbuffer before parsing it; GetRoot() reads the
+    // trailing bytes with no bounds check and would otherwise underflow on a
+    // truncated/empty custom_options blob.
+    if (flexbuffers::VerifyBuffer(custom_options_data, custom_options_size)) {
+      auto op_config =
+          flexbuffers::GetRoot(custom_options_data, custom_options_size).AsMap();
+      return op_config["max_classes_per_detection"].AsInt32();
+    }
   }
   return max_classes_per_detection;
 }
@@ -590,6 +599,16 @@ absl::Status ConfigureOutModelNmsTensorsToDetectionsCalculator(
          *metadata_extractor->GetCustomMetadataList()) {
       if (custom_metadata->name()->str() == kDetectorMetadataName) {
         found_detector_metadata = true;
+        // The DETECTOR_METADATA blob is an untrusted, separately-encoded
+        // flatbuffer embedded in the model metadata; verify it before parsing.
+        flatbuffers::Verifier options_verifier(
+            custom_metadata->data()->data(), custom_metadata->data()->size());
+        if (!VerifyObjectDetectorOptionsBuffer(options_verifier)) {
+          return CreateStatusWithPayload(
+              absl::StatusCode::kInvalidArgument,
+              "Invalid ObjectDetectorOptions in DETECTOR_METADATA.",
+              MediaPipeTasksStatus::kMetadataInvalidSchemaVersionError);
+        }
         const auto* tensors_decoding_options =
             GetObjectDetectorOptions(custom_metadata->data()->data())
                 ->tensors_decoding_options();
@@ -656,6 +675,16 @@ absl::Status ConfigureSsdAnchorsCalculator(
          *metadata_extractor->GetCustomMetadataList()) {
       if (custom_metadata->name()->str() == kDetectorMetadataName) {
         found_detector_metadata = true;
+        // The DETECTOR_METADATA blob is an untrusted, separately-encoded
+        // flatbuffer embedded in the model metadata; verify it before parsing.
+        flatbuffers::Verifier options_verifier(
+            custom_metadata->data()->data(), custom_metadata->data()->size());
+        if (!VerifyObjectDetectorOptionsBuffer(options_verifier)) {
+          return CreateStatusWithPayload(
+              absl::StatusCode::kInvalidArgument,
+              "Invalid ObjectDetectorOptions in DETECTOR_METADATA.",
+              MediaPipeTasksStatus::kMetadataInvalidSchemaVersionError);
+        }
         const auto* ssd_anchors_options =
             GetObjectDetectorOptions(custom_metadata->data()->data())
                 ->ssd_anchors_options();


### PR DESCRIPTION
### Summary
`detection_postprocessing_graph.cc` parses two untrusted, model-embedded buffers with no verification,
plus one missing null-check:

1. **Nested `ObjectDetectorOptions` flatbuffer.** `ConfigureOutModelNmsTensorsToDetectionsCalculator`
   and `ConfigureSsdAnchorsCalculator` call `GetObjectDetectorOptions(custom_metadata->data()->data())`
   (a bare `GetRoot`, no `Verifier`) on the attacker-controlled `DETECTOR_METADATA` `CustomMetadata`
   blob. The outer metadata verifier only checks the byte-vector length, not that the bytes form a
   valid nested flatbuffer, so a malformed blob leads to an out-of-bounds read / wild-pointer walk.

2. **`flexbuffers::GetRoot` on `custom_options`.** `GetMaxClassesPerDetection` calls
   `flexbuffers::GetRoot(custom_options->Data(), custom_options->size())` with no
   `flexbuffers::VerifyBuffer`. `GetRoot` reads the trailing bytes to seed parsing, so a 0/1-byte
   `custom_options` underflows before the buffer start.

3. **Null `custom_code()`.** The op-code search dereferences `custom_code()->str()` without checking
   `custom_code() != nullptr` (an optional field), crashing on a CUSTOM op-code lacking it.

### Impact
Out-of-bounds read / null dereference (crash / potential info disclosure) during
`ObjectDetector::Create()` on a crafted model, before inference.

### Change
Verify the `ObjectDetectorOptions` buffer with `VerifyObjectDetectorOptionsBuffer` before parsing (both
sites); verify the flexbuffer with `flexbuffers::VerifyBuffer` before `GetRoot`; null-check
`custom_code()`. No behavior change for valid models.

### Notes
Reported through the Google OSS VRP (issue 546472889). Verified with AddressSanitizer PoCs against the
`GetObjectDetectorOptions` and `flexbuffers::GetRoot` sinks. Analysis was AI-assisted and
human-reviewed; I could not run the full Bazel build locally, so please run CI.
