### PR TITLE
Add ObjectDetector.getLabels() on the Web Tasks API

### DIFF
--- a/mediapipe/tasks/web/vision/object_detector/BUILD
+++ b/mediapipe/tasks/web/vision/object_detector/BUILD
@@ -17,6 +17,7 @@ ts_library(
     visibility = ["//visibility:public"],
     deps = [
         ":object_detector_types",
+        "//mediapipe/calculators/util:detection_label_id_to_text_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
         "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/framework/formats:detection_jspb_proto",
@@ -27,6 +28,7 @@ ts_library(
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/vision/core:image_processing_options",
         "//mediapipe/tasks/web/vision/core:vision_task_runner",
+        "//mediapipe/util:label_map_jspb_proto",
         "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
@@ -57,11 +59,15 @@ ts_library(
     deps = [
         ":object_detector",
         ":object_detector_types",
+        "//mediapipe/calculators/util:detection_label_id_to_text_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/framework/formats:detection_jspb_proto",
         "//mediapipe/framework/formats:location_data_jspb_proto",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:task_runner_test_utils",
+        "//mediapipe/util:label_map_jspb_proto",
+        "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
 

--- a/mediapipe/tasks/web/vision/object_detector/object_detector.ts
+++ b/mediapipe/tasks/web/vision/object_detector/object_detector.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {DetectionLabelIdToTextCalculatorOptions} from '../../../../calculators/util/detection_label_id_to_text_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
 import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {Detection as DetectionProto} from '../../../../framework/formats/detection_pb';
@@ -26,6 +27,7 @@ import {
   VisionGraphRunner,
   VisionTaskRunner,
 } from '../../../../tasks/web/vision/core/vision_task_runner';
+import {LabelMapItem} from '../../../../util/label_map_pb';
 import {
   ImageSource,
   WasmModule,
@@ -39,6 +41,8 @@ const IMAGE_STREAM = 'input_frame_gpu';
 const NORM_RECT_STREAM = 'norm_rect';
 const DETECTIONS_STREAM = 'detections';
 const OBJECT_DETECTOR_GRAPH = 'mediapipe.tasks.vision.ObjectDetectorGraph';
+const DETECTION_LABEL_ID_TO_TEXT_CALCULATOR_NAME =
+  'DetectionLabelIdToTextCalculator';
 
 export type {ObjectDetectorOptions} from './object_detector_options';
 export type {
@@ -57,6 +61,7 @@ export {type ImageSource}; // Used in the public API
  */
 export class ObjectDetector extends VisionTaskRunner {
   private result: ObjectDetectorResult = {detections: []};
+  private labels: string[] = [];
   private readonly options = new ObjectDetectorOptionsProto();
 
   /**
@@ -191,6 +196,55 @@ export class ObjectDetector extends VisionTaskRunner {
     }
 
     return this.applyOptions(options);
+  }
+
+  protected override onGraphRefreshed(): void {
+    this.populateLabels();
+  }
+
+  /**
+   * Populate labels from DetectionLabelIdToTextCalculator in the expanded
+   * graph. The calculator is configured from TFLite Model Metadata when the
+   * ObjectDetector graph is built.
+   */
+  private populateLabels(): void {
+    const graphConfig = this.getCalculatorGraphConfig();
+    const labelCalculators = graphConfig.getNodeList().filter(
+      (n: CalculatorGraphConfig.Node) =>
+        n.getName().includes(DETECTION_LABEL_ID_TO_TEXT_CALCULATOR_NAME) ||
+        n.getCalculator().includes(DETECTION_LABEL_ID_TO_TEXT_CALCULATOR_NAME),
+    );
+
+    this.labels = [];
+    if (labelCalculators.length > 1) {
+      throw new Error(
+        `The graph has more than one ${DETECTION_LABEL_ID_TO_TEXT_CALCULATOR_NAME}.`,
+      );
+    } else if (labelCalculators.length === 1) {
+      const labelItems =
+        labelCalculators[0]
+          .getOptions()
+          ?.getExtension(DetectionLabelIdToTextCalculatorOptions.ext)
+          ?.getLabelItemsMap() ?? new Map<string, LabelMapItem>();
+      labelItems.forEach((value, index) => {
+        this.labels[Number(index)] = value.getName()!;
+      });
+    }
+  }
+
+  /**
+   * Get the category label list the ObjectDetector can recognize. The index in
+   * the returned array corresponds to the category index in the model label
+   * map.
+   *
+   * If there is no labelmap provided in the model file, an empty array is
+   * returned.
+   *
+   * @export
+   * @return The labels used by the current model.
+   */
+  getLabels(): string[] {
+    return this.labels;
   }
 
   /**

--- a/mediapipe/tasks/web/vision/object_detector/object_detector_test.ts
+++ b/mediapipe/tasks/web/vision/object_detector/object_detector_test.ts
@@ -17,7 +17,9 @@
 import 'jasmine';
 
 // Placeholder for internal dependency on encodeByteArray
+import {DetectionLabelIdToTextCalculatorOptions} from '../../../../calculators/util/detection_label_id_to_text_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {Detection as DetectionProto} from '../../../../framework/formats/detection_pb';
 import {LocationData} from '../../../../framework/formats/location_data_pb';
 import {
@@ -28,6 +30,11 @@ import {
   verifyGraph,
   verifyListenersRegistered,
 } from '../../../../tasks/web/core/task_runner_test_utils';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+import {
+  CALCULATOR_GRAPH_CONFIG_LISTENER_NAME,
+  SimpleListener,
+} from '../../../../web/graph_runner/graph_runner';
 
 import {ObjectDetector} from './object_detector';
 import type {ObjectDetectorOptions} from './object_detector_options';
@@ -230,6 +237,70 @@ describe('ObjectDetector', () => {
       ],
       boundingBox: {originX: 0, originY: 0, width: 0, height: 0, angle: 0},
       keypoints: [],
+    });
+  });
+
+  describe('getLabels()', () => {
+    function graphConfigWithLabels(labels: string[]): Uint8Array {
+      const graph = new CalculatorGraphConfig();
+      const node = new CalculatorGraphConfig.Node();
+      node.setName('DetectionLabelIdToTextCalculator');
+      node.setCalculator('DetectionLabelIdToTextCalculator');
+
+      const labelOptions = new DetectionLabelIdToTextCalculatorOptions();
+      labels.forEach((name, index) => {
+        const item = new LabelMapItem();
+        item.setName(name);
+        labelOptions.getLabelItemsMap().set(index, item);
+      });
+
+      const calculatorOptions = new CalculatorOptions();
+      calculatorOptions.setExtension(
+        DetectionLabelIdToTextCalculatorOptions.ext,
+        labelOptions,
+      );
+      node.setOptions(calculatorOptions);
+      graph.addNode(node);
+      return graph.serializeBinary();
+    }
+
+    it('returns an empty list when the model has no labelmap', () => {
+      expect(objectDetector.getLabels()).toEqual([]);
+    });
+
+    it('returns labels from the model metadata labelmap', async () => {
+      objectDetector.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (
+          objectDetector.fakeWasmModule.simpleListeners![
+            CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+          ] as SimpleListener<Uint8Array>
+        )(
+          graphConfigWithLabels(['person', 'bicycle', 'car']),
+          0,
+        );
+      });
+
+      await objectDetector.setOptions({
+        baseOptions: {modelAssetBuffer: new Uint8Array([])},
+      });
+
+      expect(objectDetector.getLabels()).toEqual(['person', 'bicycle', 'car']);
+    });
+
+    it('reloads labels when the model is swapped', async () => {
+      objectDetector.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (
+          objectDetector.fakeWasmModule.simpleListeners![
+            CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+          ] as SimpleListener<Uint8Array>
+        )(graphConfigWithLabels(['cat', 'dog']), 0);
+      });
+
+      await objectDetector.setOptions({
+        baseOptions: {modelAssetBuffer: new Uint8Array([1, 2, 3])},
+      });
+
+      expect(objectDetector.getLabels()).toEqual(['cat', 'dog']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Apps that let users swap or upload a custom object-detector `.tflite` cannot show that model's class list without hardcoding it. `detect()` only returns categories for objects that actually fire.
- Adds `ObjectDetector.getLabels(): string[]` on the Web Tasks API, matching `ImageSegmenter.getLabels()`.
- After graph refresh, reads the labelmap already written onto `DetectionLabelIdToTextCalculator` from TFLite Model Metadata. Returns `[]` when the model has no label file. Reloads when `setOptions()` loads a new model.

Fixes #6294

## Test plan
- [x] Unit tests in `object_detector_test.ts`: empty labelmap, EfficientDet-style labels, labels refresh after model swap
- [ ] `bazel test //mediapipe/tasks/web/vision/object_detector:object_detector_test`
- [ ] Manual: `ObjectDetector.createFromOptions` with [efficientdet_lite0](https://storage.googleapis.com/mediapipe-models/object_detector/efficientdet_lite0/float32/latest/efficientdet_lite0.tflite), then `detector.getLabels()` lists COCO classes (person, bicycle, car, …) without running `detect()`
- [ ] Repeat with a custom `.tflite` that has metadata labels, then swap models via `setOptions({ baseOptions: { modelAssetPath } })` and confirm `getLabels()` updates