### PR TITLE
Add selfieMode to Web vision landmark tasks

### DIFF
--- a/mediapipe/tasks/web/vision/core/BUILD
+++ b/mediapipe/tasks/web/vision/core/BUILD
@@ -122,6 +122,7 @@ ts_library(
         ":mask",
         ":vision_task_options",
         "//mediapipe/framework/formats:rect_jspb_proto",
+        "//mediapipe/tasks/web/components/containers:landmark",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:task_runner",
         "//mediapipe/web/graph_runner:graph_runner_image_lib_ts",

--- a/mediapipe/tasks/web/vision/core/vision_task_options.d.ts
+++ b/mediapipe/tasks/web/vision/core/vision_task_options.d.ts
@@ -40,4 +40,15 @@ export declare interface VisionTaskOptions extends TaskRunnerOptions {
    * 2) The video mode for processing decoded frames of a video.
    */
   runningMode?: RunningMode;
+
+  /**
+   * Whether to treat input frames as a front-facing / selfie camera.
+   *
+   * When true, normalized landmark `x` values are mirrored (`x' = 1 - x`) and
+   * world landmark `x` values are negated so overlays line up with a
+   * horizontally flipped canvas, matching the `selfieMode` option from the
+   * legacy `@mediapipe/pose` / `@mediapipe/hands` solutions. Defaults to
+   * `false`.
+   */
+  selfieMode?: boolean;
 }

--- a/mediapipe/tasks/web/vision/core/vision_task_runner.ts
+++ b/mediapipe/tasks/web/vision/core/vision_task_runner.ts
@@ -15,6 +15,10 @@
  */
 
 import {NormalizedRect} from '../../../../framework/formats/rect_pb';
+import {
+  Landmark,
+  NormalizedLandmark,
+} from '../../../../tasks/web/components/containers/landmark';
 import {TaskRunner} from '../../../../tasks/web/core/task_runner';
 import {WasmFileset} from '../../../../tasks/web/core/wasm_fileset';
 import {MPImage} from '../../../../tasks/web/vision/core/image';
@@ -63,6 +67,7 @@ function createCanvas(): HTMLCanvasElement | OffscreenCanvas | undefined {
 export abstract class VisionTaskRunner extends TaskRunner {
   private readonly shaderContext = new MPImageShaderContext();
   private isStreamMode = false;
+  private selfieModeEnabled = false;
 
   protected static async createVisionInstance<T extends VisionTaskRunner>(
     type: WasmMediaPipeConstructor<T>,
@@ -113,6 +118,10 @@ export abstract class VisionTaskRunner extends TaskRunner {
       this.baseOptions.setUseStreamMode(this.isStreamMode);
     }
 
+    if ('selfieMode' in options) {
+      this.selfieModeEnabled = !!options.selfieMode;
+    }
+
     if (options.canvas !== undefined) {
       if (this.graphRunner.wasmModule.canvas !== options.canvas) {
         throw new Error('You must create a new task to reset the canvas.');
@@ -149,6 +158,30 @@ export abstract class VisionTaskRunner extends TaskRunner {
       );
     }
     this.process(imageFrame, imageProcessingOptions, timestamp);
+  }
+
+  /**
+   * Mirrors normalized landmarks horizontally when `selfieMode` is enabled so
+   * overlays match a front-facing camera canvas (`x' = 1 - x`).
+   */
+  protected mirrorNormalizedLandmarksIfNeeded(
+    landmarks: NormalizedLandmark[],
+  ): NormalizedLandmark[] {
+    if (!this.selfieModeEnabled) {
+      return landmarks;
+    }
+    return landmarks.map((landmark) => ({...landmark, x: 1 - landmark.x}));
+  }
+
+  /**
+   * Mirrors world landmarks horizontally when `selfieMode` is enabled
+   * (`x' = -x`).
+   */
+  protected mirrorWorldLandmarksIfNeeded(landmarks: Landmark[]): Landmark[] {
+    if (!this.selfieModeEnabled) {
+      return landmarks;
+    }
+    return landmarks.map((landmark) => ({...landmark, x: -landmark.x}));
   }
 
   private convertToNormalizedRect(

--- a/mediapipe/tasks/web/vision/core/vision_task_runner_test.ts
+++ b/mediapipe/tasks/web/vision/core/vision_task_runner_test.ts
@@ -111,6 +111,20 @@ class VisionTaskRunnerFake extends VisionTaskRunner {
     super.processVideoData(imageFrame, imageProcessingOptions, timestamp);
   }
 
+  override mirrorNormalizedLandmarksIfNeeded(
+    landmarks: Parameters<
+      VisionTaskRunner['mirrorNormalizedLandmarksIfNeeded']
+    >[0],
+  ) {
+    return super.mirrorNormalizedLandmarksIfNeeded(landmarks);
+  }
+
+  override mirrorWorldLandmarksIfNeeded(
+    landmarks: Parameters<VisionTaskRunner['mirrorWorldLandmarksIfNeeded']>[0],
+  ) {
+    return super.mirrorWorldLandmarksIfNeeded(landmarks);
+  }
+
   expectNormalizedRect(
     xCenter: number,
     yCenter: number,
@@ -228,7 +242,29 @@ describe('VisionTaskRunner', () => {
     await visionTaskRunner.setOptions({canvas});
     await visionTaskRunner.setOptions({canvas: undefined});
 
-    expect(visionTaskRunner.graphRunner.wasmModule.canvas).toBe(canvas);
+    expect(
+      visionTaskRunner.graphRunner.wasmModule.canvas,
+    ).toBe(canvas);
+  });
+
+  it('can enable selfieMode', async () => {
+    const visionTaskRunner = new VisionTaskRunnerFake();
+    const landmarks = visionTaskRunner.mirrorNormalizedLandmarksIfNeeded([
+      {x: 0.25, y: 0.4, z: 0.1, visibility: 1},
+    ]);
+    expect(landmarks).toEqual([{x: 0.25, y: 0.4, z: 0.1, visibility: 1}]);
+
+    await visionTaskRunner.setOptions({selfieMode: true});
+    expect(
+      visionTaskRunner.mirrorNormalizedLandmarksIfNeeded([
+        {x: 0.25, y: 0.4, z: 0.1, visibility: 1},
+      ]),
+    ).toEqual([{x: 0.75, y: 0.4, z: 0.1, visibility: 1}]);
+    expect(
+      visionTaskRunner.mirrorWorldLandmarksIfNeeded([
+        {x: 0.3, y: 0.1, z: 0.2, visibility: 1},
+      ]),
+    ).toEqual([{x: -0.3, y: 0.1, z: 0.2, visibility: 1}]);
   });
 
   it('sends packets to graph', async () => {

--- a/mediapipe/tasks/web/vision/face_landmarker/face_landmarker.ts
+++ b/mediapipe/tasks/web/vision/face_landmarker/face_landmarker.ts
@@ -372,7 +372,11 @@ export class FaceLandmarker extends VisionTaskRunner {
     for (const binaryProto of data) {
       const faceLandmarksProto =
         NormalizedLandmarkListProto.deserializeBinary(binaryProto);
-      this.result.faceLandmarks.push(convertToLandmarks(faceLandmarksProto));
+      this.result.faceLandmarks.push(
+        this.mirrorNormalizedLandmarksIfNeeded(
+          convertToLandmarks(faceLandmarksProto),
+        ),
+      );
     }
   }
 

--- a/mediapipe/tasks/web/vision/gesture_recognizer/gesture_recognizer.ts
+++ b/mediapipe/tasks/web/vision/gesture_recognizer/gesture_recognizer.ts
@@ -392,7 +392,7 @@ export class GestureRecognizer extends VisionTaskRunner {
           visibility: handLandmarkProto.getVisibility() ?? 0,
         });
       }
-      this.landmarks.push(landmarks);
+      this.landmarks.push(this.mirrorNormalizedLandmarksIfNeeded(landmarks));
     }
   }
 
@@ -413,7 +413,9 @@ export class GestureRecognizer extends VisionTaskRunner {
           visibility: handWorldLandmarkProto.getVisibility() ?? 0,
         });
       }
-      this.worldLandmarks.push(worldLandmarks);
+      this.worldLandmarks.push(
+        this.mirrorWorldLandmarksIfNeeded(worldLandmarks),
+      );
     }
   }
 

--- a/mediapipe/tasks/web/vision/hand_landmarker/hand_landmarker.ts
+++ b/mediapipe/tasks/web/vision/hand_landmarker/hand_landmarker.ts
@@ -316,7 +316,11 @@ export class HandLandmarker extends VisionTaskRunner {
     for (const binaryProto of data) {
       const handLandmarksProto =
         NormalizedLandmarkList.deserializeBinary(binaryProto);
-      this.landmarks.push(convertToLandmarks(handLandmarksProto));
+      this.landmarks.push(
+        this.mirrorNormalizedLandmarksIfNeeded(
+          convertToLandmarks(handLandmarksProto),
+        ),
+      );
     }
   }
 
@@ -329,7 +333,9 @@ export class HandLandmarker extends VisionTaskRunner {
       const handWorldLandmarksProto =
         LandmarkList.deserializeBinary(binaryProto);
       this.worldLandmarks.push(
-        convertToWorldLandmarks(handWorldLandmarksProto),
+        this.mirrorWorldLandmarksIfNeeded(
+          convertToWorldLandmarks(handWorldLandmarksProto),
+        ),
       );
     }
   }

--- a/mediapipe/tasks/web/vision/holistic_landmarker/holistic_landmarker.ts
+++ b/mediapipe/tasks/web/vision/holistic_landmarker/holistic_landmarker.ts
@@ -640,7 +640,9 @@ export class HolisticLandmarker extends VisionTaskRunner {
     outputList: NormalizedLandmark[][],
   ): void {
     const landmarksProto = NormalizedLandmarkList.deserializeBinary(data);
-    outputList.push(convertToLandmarks(landmarksProto));
+    outputList.push(
+      this.mirrorNormalizedLandmarksIfNeeded(convertToLandmarks(landmarksProto)),
+    );
   }
 
   /**
@@ -652,7 +654,11 @@ export class HolisticLandmarker extends VisionTaskRunner {
     outputList: Landmark[][],
   ): void {
     const worldLandmarksProto = LandmarkList.deserializeBinary(data);
-    outputList.push(convertToWorldLandmarks(worldLandmarksProto));
+    outputList.push(
+      this.mirrorWorldLandmarksIfNeeded(
+        convertToWorldLandmarks(worldLandmarksProto),
+      ),
+    );
   }
 
   /** Adds new blendshapes from the given proto. */

--- a/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker.ts
+++ b/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker.ts
@@ -458,7 +458,11 @@ export class PoseLandmarker extends VisionTaskRunner {
     for (const binaryProto of data) {
       const poseLandmarksProto =
         NormalizedLandmarkList.deserializeBinary(binaryProto);
-      this.landmarks.push(convertToLandmarks(poseLandmarksProto));
+      this.landmarks.push(
+        this.mirrorNormalizedLandmarksIfNeeded(
+          convertToLandmarks(poseLandmarksProto),
+        ),
+      );
     }
   }
 
@@ -472,7 +476,9 @@ export class PoseLandmarker extends VisionTaskRunner {
       const poseWorldLandmarksProto =
         LandmarkList.deserializeBinary(binaryProto);
       this.worldLandmarks.push(
-        convertToWorldLandmarks(poseWorldLandmarksProto),
+        this.mirrorWorldLandmarksIfNeeded(
+          convertToWorldLandmarks(poseWorldLandmarksProto),
+        ),
       );
     }
   }

--- a/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker_test.ts
+++ b/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker_test.ts
@@ -260,6 +260,36 @@ describe('PoseLandmarker', () => {
     });
   });
 
+  it('mirrors landmarks when selfieMode is enabled', (done) => {
+    const landmarksProto = [createLandmarks(0.25, 0.4, 0.1).serializeBinary()];
+    const worldLandmarksProto = [
+      createWorldLandmarks(0.3, 0.1, 0.2).serializeBinary(),
+    ];
+
+    poseLandmarker.setOptions({selfieMode: true}).then(() => {
+      poseLandmarker.fakeWasmModule._waitUntilIdle.and.callFake(() => {
+        poseLandmarker.listeners.get('normalized_landmarks')!(
+          landmarksProto,
+          1337,
+        );
+        poseLandmarker.listeners.get('world_landmarks')!(
+          worldLandmarksProto,
+          1337,
+        );
+      });
+
+      poseLandmarker.detect({} as HTMLImageElement, (result) => {
+        expect(result.landmarks).toEqual([
+          [{'x': 0.75, 'y': 0.4, 'z': 0.1, 'visibility': 0}],
+        ]);
+        expect(result.worldLandmarks).toEqual([
+          [{'x': -0.3, 'y': 0.1, 'z': 0.2, 'visibility': 0}],
+        ]);
+        done();
+      });
+    });
+  });
+
   it('clears results between invoations', async () => {
     const landmarksProto = [createLandmarks().serializeBinary()];
     const worldLandmarksProto = [createWorldLandmarks().serializeBinary()];


### PR DESCRIPTION
## Summary
- Legacy `@mediapipe/pose` / `@mediapipe/hands` had `selfieMode` so front-camera overlays line up with a mirrored canvas. Tasks landmarker results stayed in unmirrored coordinates, so mixing the two APIs meant drawing two coordinate systems.
- Adds `selfieMode?: boolean` on `VisionTaskOptions` (PoseLandmarker, HandLandmarker, FaceLandmarker, HolisticLandmarker, GestureRecognizer).
- When true, normalized landmark `x` is mirrored (`1 - x`) and world landmark `x` is negated. Default remains `false`.

Fixes #5900

## Test plan
- [x] Unit tests: `VisionTaskRunner` mirrors only when `selfieMode` is set; `PoseLandmarker.detect` returns `x' = 1-x` / world `x' = -x`
- [ ] `bazel test //mediapipe/tasks/web/vision/core:vision_task_runner_test //mediapipe/tasks/web/vision/pose_landmarker:pose_landmarker_test`
- [ ] Manual: webcam `detectForVideo` with `selfieMode: true`, draw landmarks on a horizontally flipped canvas — they should overlay the person. With `false`, they overlay an unmirrored frame.