### PR TITLE
Add onLoadingProgress for Web Wasm and model downloads

### DIFF
--- a/mediapipe/tasks/web/core/BUILD
+++ b/mediapipe/tasks/web/core/BUILD
@@ -42,10 +42,16 @@ ts_library(
 )
 
 ts_library(
+    name = "loading_progress",
+    srcs = ["loading_progress.ts"],
+)
+
+ts_library(
     name = "task_runner",
     srcs = ["task_runner.ts"],
     deps = [
         ":core",
+        ":loading_progress",
         ":task_logger",
         ":task_logger_factory",
         "//mediapipe/calculators/tensor:inference_calculator_jspb_proto",

--- a/mediapipe/tasks/web/core/loading_progress.ts
+++ b/mediapipe/tasks/web/core/loading_progress.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2026 The MediaPipe Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reads a fetch Response into an ArrayBuffer, invoking `onProgress` as bytes
+ * arrive when `response.body` is a ReadableStream.
+ *
+ * If the body is unavailable (older fetch mocks / environments), falls back to
+ * `arrayBuffer()` and reports a single completed event.
+ */
+export async function readResponseArrayBufferWithProgress(
+  response: Response,
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<ArrayBuffer> {
+  const total = Number(response.headers?.get?.('content-length')) || 0;
+
+  if (!onProgress || !response.body) {
+    const buffer = await response.arrayBuffer();
+    onProgress?.(buffer.byteLength, total || buffer.byteLength);
+    return buffer;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let loaded = 0;
+
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    }
+    chunks.push(value);
+    loaded += value.byteLength;
+    onProgress(loaded, total);
+  }
+
+  const result = new Uint8Array(loaded);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result.buffer;
+}
+
+/**
+ * Fetches `url` as an ArrayBuffer. Throws if the response is not OK.
+ *
+ * @param url The resource to download.
+ * @param onProgress Optional byte-progress callback.
+ * @param errorLabel Prefix used in the thrown Error, e.g. `model: foo.tflite`.
+ */
+export async function fetchArrayBufferWithProgress(
+  url: string,
+  onProgress?: (loaded: number, total: number) => void,
+  errorLabel?: string,
+): Promise<ArrayBuffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${errorLabel ?? url} (${response.status})`,
+    );
+  }
+  return readResponseArrayBufferWithProgress(response, onProgress);
+}

--- a/mediapipe/tasks/web/core/task_runner.ts
+++ b/mediapipe/tasks/web/core/task_runner.ts
@@ -21,6 +21,7 @@ import {BaseOptions as BaseOptionsProto} from '../../../tasks/cc/core/proto/base
 import {ExternalFile} from '../../../tasks/cc/core/proto/external_file_pb';
 import {
   BaseOptions,
+  LoadingProgressEvent,
   TaskRunnerOptions,
 } from '../../../tasks/web/core/task_runner_options';
 import {streamToUint8Array} from '../../../tasks/web/genai/llm_inference/model_loading_utils';
@@ -32,6 +33,7 @@ import {
 } from '../../../web/graph_runner/graph_runner';
 import {SupportLogging} from '../../../web/graph_runner/graph_runner_logging_lib';
 import {SupportModelResourcesGraphService} from '../../../web/graph_runner/register_model_resources_graph_service';
+import {fetchArrayBufferWithProgress} from './loading_progress';
 import {TaskLogger} from './task_logger';
 import {createTasksLogger} from './task_logger_factory';
 
@@ -81,6 +83,30 @@ export async function createTaskRunner<T extends TaskRunner>(
     },
   };
 
+  // When a progress callback is provided, prefetch Wasm (and optional .data
+  // assets) so the app can show a loading bar. Passing the bytes into
+  // Emscripten avoids a second download.
+  const onLoadingProgress = options.onLoadingProgress;
+  if (onLoadingProgress) {
+    fileLocator.wasmBinary = await fetchArrayBufferWithProgress(
+      fileset.wasmBinaryPath.toString(),
+      (loaded, total) => {
+        onLoadingProgress({type: 'wasm', loaded, total});
+      },
+      fileset.wasmBinaryPath.toString(),
+    );
+    if (fileset.assetBinaryPath) {
+      const assetBinary = await fetchArrayBufferWithProgress(
+        fileset.assetBinaryPath.toString(),
+        (loaded, total) => {
+          onLoadingProgress({type: 'asset', loaded, total});
+        },
+        fileset.assetBinaryPath.toString(),
+      );
+      fileLocator.getPreloadedPackage = () => assetBinary;
+    }
+  }
+
   const instance = await createMediaPipeLib(
     type,
     fileset.wasmLoaderPath,
@@ -100,6 +126,7 @@ export abstract class TaskRunner {
   private processingErrors: Error[] = [];
   private latestOutputTimestamp = 0;
   private keepaliveNode?: CalculatorGraphConfig.Node;
+  private onLoadingProgress?: (event: LoadingProgressEvent) => void;
 
   /**
    * Creates a new instance of a Mediapipe Task. Determines if SIMD is
@@ -149,6 +176,10 @@ export abstract class TaskRunner {
     options: TaskRunnerOptions,
     loadTfliteModel = true,
   ): Promise<void> {
+    if ('onLoadingProgress' in options) {
+      this.onLoadingProgress = options.onLoadingProgress;
+    }
+
     if (loadTfliteModel) {
       const baseOptions: BaseOptions = options.baseOptions || {};
 
@@ -175,38 +206,38 @@ export abstract class TaskRunner {
 
       this.setAcceleration(baseOptions);
       if (baseOptions.modelAssetPath) {
+        const modelUrl = baseOptions.modelAssetPath.toString();
+        const onProgress = this.onLoadingProgress;
         // We don't use `await` here since we want to apply most settings
         // synchronously.
-        return fetch(baseOptions.modelAssetPath.toString())
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error(
-                `Failed to fetch model: ${baseOptions.modelAssetPath} (${response.status})`,
-              );
-            } else {
-              return response.arrayBuffer();
-            }
-          })
-          .then((buffer) => {
-            try {
-              // Try to delete file as we cannot overwrite an existing file
-              // using our current API.
-              this.graphRunner.wasmModule.FS_unlink('/model.dat');
-            } catch {}
-            // TODO: Consider passing the model to the graph as an
-            // input side packet as this might reduce copies.
-            this.graphRunner.wasmModule.FS_createDataFile(
-              '/',
-              'model.dat',
-              new Uint8Array(buffer),
-              /* canRead= */ true,
-              /* canWrite= */ false,
-              /* canOwn= */ false,
-            );
-            this.setExternalFile('/model.dat');
-            this.refreshGraph();
-            this.onGraphRefreshed();
-          });
+        return fetchArrayBufferWithProgress(
+          modelUrl,
+          onProgress
+            ? (loaded, total) => {
+                onProgress({type: 'model', loaded, total});
+              }
+            : undefined,
+          `model: ${modelUrl}`,
+        ).then((buffer) => {
+          try {
+            // Try to delete file as we cannot overwrite an existing file
+            // using our current API.
+            this.graphRunner.wasmModule.FS_unlink('/model.dat');
+          } catch {}
+          // TODO: Consider passing the model to the graph as an
+          // input side packet as this might reduce copies.
+          this.graphRunner.wasmModule.FS_createDataFile(
+            '/',
+            'model.dat',
+            new Uint8Array(buffer),
+            /* canRead= */ true,
+            /* canWrite= */ false,
+            /* canOwn= */ false,
+          );
+          this.setExternalFile('/model.dat');
+          this.refreshGraph();
+          this.onGraphRefreshed();
+        });
       } else if (baseOptions.modelAssetBuffer instanceof Uint8Array) {
         this.setExternalFile(baseOptions.modelAssetBuffer);
       } else if (baseOptions.modelAssetBuffer) {

--- a/mediapipe/tasks/web/core/task_runner_options.d.ts
+++ b/mediapipe/tasks/web/core/task_runner_options.d.ts
@@ -34,8 +34,42 @@ export declare interface BaseOptions {
   delegate?: 'CPU' | 'GPU' | undefined;
 }
 
+/**
+ * Which download `onLoadingProgress` is reporting.
+ *
+ * - `'wasm'`: the task's WebAssembly binary
+ * - `'asset'`: the optional Emscripten `.data` package (tasks that ship extra
+ *   assets)
+ * - `'model'`: the TFLite / task model from `baseOptions.modelAssetPath`
+ */
+export type LoadingResourceType = 'wasm'|'asset'|'model';
+
+/** Progress of a Wasm, asset, or model download. Use this to drive a loading bar. */
+export declare interface LoadingProgressEvent {
+  /** The resource currently being downloaded. */
+  type: LoadingResourceType;
+  /** Bytes received so far. */
+  loaded: number;
+  /**
+   * Total size in bytes when the server sends `Content-Length`.
+   * `0` if the size is not known (show an indeterminate bar).
+   */
+  total: number;
+}
+
 /** Options to configure MediaPipe Tasks in general. */
 export declare interface TaskRunnerOptions {
   /** Options to configure the loading of the model assets. */
   baseOptions?: BaseOptions;
+
+  /**
+   * Called as the Wasm binary, optional `.data` assets, and model file
+   * download. Apps can use `loaded / total` (when `total > 0`) to show a
+   * loading bar. Downloads of ~10MB each otherwise leave the UI stalled with
+   * no feedback.
+   *
+   * Omitted by default. Pass `undefined` in a later `setOptions()` call to
+   * stop receiving events.
+   */
+  onLoadingProgress?: ((event: LoadingProgressEvent) => void)|undefined;
 }

--- a/mediapipe/tasks/web/core/task_runner_test.ts
+++ b/mediapipe/tasks/web/core/task_runner_test.ts
@@ -418,6 +418,122 @@ describe('TaskRunner', () => {
     ).toBeRejectedWithError('Failed to fetch model: notfound.tflite (404)');
   });
 
+  it('reports model download progress from a streamed body', async () => {
+    if (typeof ReadableStream === 'undefined') return; // No Node support
+
+    fetchSpy.and.callFake(async () => {
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0, 1]));
+          controller.enqueue(new Uint8Array([2, 3]));
+          controller.close();
+        },
+      });
+      return {
+        ok: true,
+        status: 200,
+        headers: {get: (name: string) => name.toLowerCase() === 'content-length' ? '4' : null},
+        body,
+        arrayBuffer: () => mockBytes.buffer,
+      } as unknown as Response;
+    });
+
+    const events: Array<{type: string; loaded: number; total: number}> = [];
+    await taskRunner.setOptions({
+      baseOptions: {modelAssetPath: `foo.tflite`},
+      onLoadingProgress: (event) => {
+        events.push({...event});
+      },
+    });
+
+    expect(events).toEqual([
+      {type: 'model', loaded: 2, total: 4},
+      {type: 'model', loaded: 4, total: 4},
+    ]);
+    expect(taskRunner.baseOptions.toObject()).toEqual(mockFileResult);
+  });
+
+  it('reports a completed model progress event when the body is not a stream', async () => {
+    const events: Array<{type: string; loaded: number; total: number}> = [];
+    await taskRunner.setOptions({
+      baseOptions: {modelAssetPath: `foo.tflite`},
+      onLoadingProgress: (event) => {
+        events.push({...event});
+      },
+    });
+
+    expect(events).toEqual([{type: 'model', loaded: 4, total: 4}]);
+  });
+
+  it('does not prefetch Wasm when onLoadingProgress is omitted', () => {
+    const fileset: WasmFileset = {
+      wasmLoaderPath: `wasm.js`,
+      wasmBinaryPath: `a/b/c/wasm.wasm`,
+    };
+    createTaskRunner(TaskRunnerFake, null, fileset, {
+      baseOptions: {modelAssetPath: `modelAssetPath`},
+    });
+    expect(locator?.wasmBinary).toBeUndefined();
+    expect(locator?.getPreloadedPackage).toBeUndefined();
+  });
+
+  it('prefetches Wasm and reports progress when onLoadingProgress is set', async () => {
+    const fileset: WasmFileset = {
+      wasmLoaderPath: `wasm.js`,
+      wasmBinaryPath: `a/b/c/wasm.wasm`,
+    };
+    const events: Array<{type: string; loaded: number; total: number}> = [];
+
+    await createTaskRunner(TaskRunnerFake, null, fileset, {
+      baseOptions: {modelAssetPath: `modelAssetPath`},
+      onLoadingProgress: (event) => {
+        events.push({...event});
+      },
+    });
+
+    expect(locator?.wasmBinary).toBeDefined();
+    expect(fetchSpy).toHaveBeenCalledWith('a/b/c/wasm.wasm');
+    expect(fetchSpy).toHaveBeenCalledWith('modelAssetPath');
+    expect(events.map((e) => e.type)).toEqual(['wasm', 'model']);
+  });
+
+  it('prefetches .data assets and reports progress', async () => {
+    const fileset: WasmFileset = {
+      wasmLoaderPath: `wasm.js`,
+      wasmBinaryPath: `a/b/c/wasm.wasm`,
+      assetLoaderPath: `asset.js`,
+      assetBinaryPath: `a/b/c/asset.data`,
+    };
+    const events: Array<{type: string}> = [];
+
+    await createTaskRunner(TaskRunnerFake, null, fileset, {
+      baseOptions: {modelAssetPath: `modelAssetPath`},
+      onLoadingProgress: (event) => {
+        events.push({type: event.type});
+      },
+    });
+
+    expect(locator?.getPreloadedPackage).toBeDefined();
+    expect(fetchSpy).toHaveBeenCalledWith('a/b/c/asset.data');
+    expect(events.map((e) => e.type)).toEqual(['wasm', 'asset', 'model']);
+  });
+
+  it('keeps onLoadingProgress across later setOptions calls', async () => {
+    const events: string[] = [];
+    await taskRunner.setOptions({
+      baseOptions: {modelAssetPath: `foo.tflite`},
+      onLoadingProgress: (event) => {
+        events.push(event.type);
+      },
+    });
+    events.length = 0;
+
+    await taskRunner.setOptions({
+      baseOptions: {modelAssetPath: `bar.tflite`},
+    });
+    expect(events).toEqual(['model']);
+  });
+
   it('can enable CPU delegate', async () => {
     await taskRunner.setOptions({
       baseOptions: {

--- a/mediapipe/web/graph_runner/graph_runner.ts
+++ b/mediapipe/web/graph_runner/graph_runner.ts
@@ -1204,6 +1204,14 @@ export const createMediaPipeLib: CreateMediaPipeLibApi = async <LibType>(
     if (fileLocator.mainScriptUrlOrBlob) {
       moduleFileLocator.mainScriptUrlOrBlob = fileLocator.mainScriptUrlOrBlob;
     }
+    // Copy preloaded binaries so progress-aware fetches are not repeated by
+    // Emscripten.
+    if (fileLocator.wasmBinary) {
+      moduleFileLocator.wasmBinary = fileLocator.wasmBinary;
+    }
+    if (fileLocator.getPreloadedPackage) {
+      moduleFileLocator.getPreloadedPackage = fileLocator.getPreloadedPackage;
+    }
   }
   // TODO: Ensure that fileLocator is passed in by all users
   // and make it required

--- a/mediapipe/web/graph_runner/graph_runner_factory_api.d.ts
+++ b/mediapipe/web/graph_runner/graph_runner_factory_api.d.ts
@@ -11,6 +11,17 @@ import {WasmModule} from './wasm_module';
 export declare interface FileLocator {
   locateFile: (filename: string) => string;
   mainScriptUrlOrBlob?: string;
+  /**
+   * Optional preloaded Wasm binary. When set, Emscripten skips fetching the
+   * `.wasm` file itself.
+   */
+  wasmBinary?: ArrayBuffer;
+  /**
+   * Optional hook to supply a preloaded `.data` asset package. When set,
+   * Emscripten skips fetching the package.
+   */
+  getPreloadedPackage?:
+      (remotePackageName: string, remotePackageSize: number) => ArrayBuffer;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wasm + model files are ~10MB each, so `FaceLandmarker.createFromOptions()` (and every other Web task) can stall ~10s with a frozen UI. Legacy `locateFile` preloading does not exist on the Tasks API.
- Adds `onLoadingProgress` on `TaskRunnerOptions` (inherited by all Web tasks). During create / `setOptions()` it reports `{type, loaded, total}` for `'wasm'`, optional `'asset'` (`.data` packages), and `'model'`.
- When the callback is set, Wasm (and `.data` if present) are prefetched and passed to Emscripten as `wasmBinary` / `getPreloadedPackage` so they are not downloaded twice. `total` is `0` if the server omits `Content-Length`. Behavior is unchanged if the callback is omitted.

Fixes #5170

## Usage

```js
const landmarker = await FaceLandmarker.createFromOptions(vision, {
  baseOptions: { modelAssetPath: modelUrl },
  onLoadingProgress: ({ type, loaded, total }) => {
    if (total > 0) {
      console.log(`${type}: ${Math.round((100 * loaded) / total)}%`);
    }
  },
});
```

## Test plan
- [x] Unit tests in `task_runner_test.ts`: streamed model progress, fallback when `response.body` is missing, no Wasm prefetch without the callback, Wasm + `.data` prefetch with progress, callback retained across later `setOptions()`
- [ ] `bazel test //mediapipe/tasks/web/core:task_runner_test` (Bazel is not installed on this machine)

@schmidt-sebastian @ayushgdev @HarishPermal @kuaashish @tyrmullen @kalyan2789g