### PR TITLE
Add Compose-friendly vision overlays for Android Tasks

### DIFF
--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/BUILD
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/BUILD
@@ -367,6 +367,30 @@ filegroup(
     visibility = ["//mediapipe/tasks/java/com/google/mediapipe/tasks/vision:__subpackages__"],
 )
 
+# Compose / XML overlay for drawing Tasks vision results. Ships in tasks-vision;
+# does not depend on Jetpack Compose so XML apps are unaffected. Compose apps wrap
+# VisionOverlayView in AndroidView or call VisionOverlayRenderer from drawIntoCanvas.
+android_library(
+    name = "overlay",
+    srcs = glob(["overlay/*.java"]),
+    manifest = "AndroidManifest.xml",
+    deps = [
+        ":core_java",
+        ":facedetector",
+        ":facelandmarker",
+        ":gesturerecognizer",
+        ":handlandmarker",
+        ":holisticlandmarker",
+        ":objectdetector",
+        ":poselandmarker",
+        "//mediapipe/tasks/java/com/google/mediapipe/tasks/components/containers:category",
+        "//mediapipe/tasks/java/com/google/mediapipe/tasks/components/containers:connection",
+        "//mediapipe/tasks/java/com/google/mediapipe/tasks/components/containers:detection",
+        "//mediapipe/tasks/java/com/google/mediapipe/tasks/components/containers:normalized_landmark",
+        "//mediapipe/tasks/java/com/google/mediapipe/tasks/components/containers:normalizedkeypoint",
+    ],
+)
+
 android_library(
     name = "holisticlandmarker",
     srcs = [

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/OverlayLayout.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/OverlayLayout.java
@@ -1,0 +1,248 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import android.graphics.Matrix;
+import android.graphics.RectF;
+import com.google.mediapipe.tasks.vision.core.RunningMode;
+
+/**
+ * Maps MediaPipe vision coordinates onto a view (Compose {@code Canvas}, {@link
+ * android.view.View}, or bitmap).
+ *
+ * <p>Normalized landmarks ({@code x}, {@code y} in {@code [0, 1]}) are multiplied by the image
+ * size, then scaled to the view. Bounding boxes from object / face detection are already in image
+ * pixels and only need scale, optional camera rotation, and optional mirroring.
+ *
+ * <p><b>Running mode</b> matches CameraX / sample {@code OverlayView} behavior:
+ *
+ * <ul>
+ *   <li>{@link RunningMode#IMAGE} and {@link RunningMode#VIDEO}: FIT_START — {@code min} scale so
+ *       the whole image is visible (letterboxed).
+ *   <li>{@link RunningMode#LIVE_STREAM}: FILL_START — {@code max} scale so the preview fills the
+ *       view (cropped), matching {@code PreviewView.ScaleType.FILL_START}.
+ * </ul>
+ *
+ * <p>Pass {@code mirrored = true} when the preview is a front camera that the UI flips
+ * horizontally (typical Compose + CameraX selfie). Landmark {@code x} becomes {@code 1 - x}.
+ */
+public final class OverlayLayout {
+  private final int viewWidth;
+  private final int viewHeight;
+  private final int imageWidth;
+  private final int imageHeight;
+  private final int rotationDegrees;
+  private final boolean mirrored;
+  private final float scale;
+  private final int rotatedImageWidth;
+  private final int rotatedImageHeight;
+
+  private OverlayLayout(
+      int viewWidth,
+      int viewHeight,
+      int imageWidth,
+      int imageHeight,
+      int rotationDegrees,
+      boolean mirrored,
+      float scale,
+      int rotatedImageWidth,
+      int rotatedImageHeight) {
+    this.viewWidth = viewWidth;
+    this.viewHeight = viewHeight;
+    this.imageWidth = imageWidth;
+    this.imageHeight = imageHeight;
+    this.rotationDegrees = rotationDegrees;
+    this.mirrored = mirrored;
+    this.scale = scale;
+    this.rotatedImageWidth = rotatedImageWidth;
+    this.rotatedImageHeight = rotatedImageHeight;
+  }
+
+  /**
+   * Builds a layout for a view that displays {@code imageWidth} x {@code imageHeight} results.
+   *
+   * @param viewWidth overlay width in pixels (Compose {@code size.width}, or {@code View} content
+   *     width)
+   * @param viewHeight overlay height in pixels
+   * @param imageWidth width of the image the task ran on, in pixels
+   * @param imageHeight height of the image the task ran on, in pixels
+   * @param runningMode IMAGE/VIDEO letterbox; LIVE_STREAM crop-to-fill
+   */
+  public static OverlayLayout create(
+      int viewWidth, int viewHeight, int imageWidth, int imageHeight, RunningMode runningMode) {
+    return create(
+        viewWidth,
+        viewHeight,
+        imageWidth,
+        imageHeight,
+        runningMode,
+        /* rotationDegrees= */ 0,
+        /* mirrored= */ false);
+  }
+
+  /**
+   * Builds a layout with optional camera-frame rotation and front-camera mirroring.
+   *
+   * @param rotationDegrees clockwise rotation of the <em>camera frame</em> relative to the overlay
+   *     (0/90/180/270). Used for object/face <em>bounding boxes</em> that are in sensor
+   *     orientation. Normalized landmarks from a task that already applied {@code
+   *     ImageProcessingOptions.rotationDegrees} should pass {@code 0} and the rotated frame size.
+   * @param mirrored {@code true} to flip landmark {@code x} and boxes horizontally (front camera)
+   */
+  public static OverlayLayout create(
+      int viewWidth,
+      int viewHeight,
+      int imageWidth,
+      int imageHeight,
+      RunningMode runningMode,
+      int rotationDegrees,
+      boolean mirrored) {
+    if (viewWidth <= 0 || viewHeight <= 0) {
+      throw new IllegalArgumentException(
+          "View size must be positive, found: " + viewWidth + "x" + viewHeight);
+    }
+    if (imageWidth <= 0 || imageHeight <= 0) {
+      throw new IllegalArgumentException(
+          "Image size must be positive, found: " + imageWidth + "x" + imageHeight);
+    }
+    int rotation = normalizeRotation(rotationDegrees);
+    int rotatedWidth = isSwapped(rotation) ? imageHeight : imageWidth;
+    int rotatedHeight = isSwapped(rotation) ? imageWidth : imageHeight;
+    float widthRatio = viewWidth / (float) rotatedWidth;
+    float heightRatio = viewHeight / (float) rotatedHeight;
+    float scale =
+        runningMode == RunningMode.LIVE_STREAM
+            ? Math.max(widthRatio, heightRatio)
+            : Math.min(widthRatio, heightRatio);
+    return new OverlayLayout(
+        viewWidth,
+        viewHeight,
+        imageWidth,
+        imageHeight,
+        rotation,
+        mirrored,
+        scale,
+        rotatedWidth,
+        rotatedHeight);
+  }
+
+  /** Overlay width in pixels. */
+  public int viewWidth() {
+    return viewWidth;
+  }
+
+  /** Overlay height in pixels. */
+  public int viewHeight() {
+    return viewHeight;
+  }
+
+  /** Unrotated image width in pixels. */
+  public int imageWidth() {
+    return imageWidth;
+  }
+
+  /** Unrotated image height in pixels. */
+  public int imageHeight() {
+    return imageHeight;
+  }
+
+  /** Normalized clockwise rotation in {@code {0, 90, 180, 270}}. */
+  public int rotationDegrees() {
+    return rotationDegrees;
+  }
+
+  /** Whether normalized {@code x} and boxes are flipped for a front camera. */
+  public boolean mirrored() {
+    return mirrored;
+  }
+
+  /**
+   * Scale applied after rotation. IMAGE/VIDEO: {@code min} (fit). LIVE_STREAM: {@code max}
+   * (fill).
+   */
+  public float scale() {
+    return scale;
+  }
+
+  /** Image width after applying {@link #rotationDegrees()}. */
+  public int rotatedImageWidth() {
+    return rotatedImageWidth;
+  }
+
+  /** Image height after applying {@link #rotationDegrees()}. */
+  public int rotatedImageHeight() {
+    return rotatedImageHeight;
+  }
+
+  /** Maps a normalized landmark X in {@code [0, 1]} to overlay pixels. */
+  public float mapX(float normalizedX) {
+    float x = mirrored ? 1.f - normalizedX : normalizedX;
+    return x * rotatedImageWidth * scale;
+  }
+
+  /** Maps a normalized landmark Y in {@code [0, 1]} to overlay pixels. */
+  public float mapY(float normalizedY) {
+    return normalizedY * rotatedImageHeight * scale;
+  }
+
+  /**
+   * Maps a bounding box in <em>unrotated image pixels</em> to overlay pixels, applying rotation
+   * then scale (and mirroring).
+   */
+  public RectF mapImageRect(RectF boxInImagePixels) {
+    if (boxInImagePixels == null) {
+      throw new IllegalArgumentException("Bounding box must not be null");
+    }
+    RectF mapped = new RectF(boxInImagePixels);
+    if (rotationDegrees != 0) {
+      Matrix matrix = new Matrix();
+      matrix.postTranslate(-imageWidth / 2.f, -imageHeight / 2.f);
+      matrix.postRotate(rotationDegrees);
+      if (isSwapped(rotationDegrees)) {
+        matrix.postTranslate(imageHeight / 2.f, imageWidth / 2.f);
+      } else {
+        matrix.postTranslate(imageWidth / 2.f, imageHeight / 2.f);
+      }
+      matrix.mapRect(mapped);
+    }
+    if (mirrored) {
+      float left = rotatedImageWidth - mapped.right;
+      float right = rotatedImageWidth - mapped.left;
+      mapped.left = left;
+      mapped.right = right;
+    }
+    mapped.left *= scale;
+    mapped.top *= scale;
+    mapped.right *= scale;
+    mapped.bottom *= scale;
+    return mapped;
+  }
+
+  static int normalizeRotation(int rotationDegrees) {
+    int rotation = rotationDegrees % 360;
+    if (rotation < 0) {
+      rotation += 360;
+    }
+    if (rotation % 90 != 0) {
+      throw new IllegalArgumentException(
+          "Expected rotation to be a multiple of 90°, found: " + rotationDegrees);
+    }
+    return rotation;
+  }
+
+  private static boolean isSwapped(int rotationDegrees) {
+    return rotationDegrees == 90 || rotationDegrees == 270;
+  }
+}

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/OverlayStyle.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/OverlayStyle.java
@@ -1,0 +1,217 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import android.graphics.Color;
+
+/**
+ * Colors and sizes for {@link VisionOverlayRenderer}. Values are in pixels; scale them by {@code
+ * density} in Compose ({@code LocalDensity.current.density}) or from {@code
+ * DisplayMetrics.density}.
+ */
+public final class OverlayStyle {
+  /** MediaPipe teal used for connections and boxes. */
+  public static final int DEFAULT_CONNECTION_COLOR = 0xFF00A3A1;
+
+  /** Landmark dots. */
+  public static final int DEFAULT_LANDMARK_COLOR = Color.YELLOW;
+
+  /** Detection box stroke. */
+  public static final int DEFAULT_BOX_COLOR = 0xFF0077CC;
+
+  private final int landmarkColor;
+  private final int connectionColor;
+  private final int boxColor;
+  private final int textColor;
+  private final int textBackgroundColor;
+  private final float landmarkRadius;
+  private final float connectionStrokeWidth;
+  private final float boxStrokeWidth;
+  private final float textSize;
+  private final float textPadding;
+
+  OverlayStyle(Builder builder) {
+    this.landmarkColor = builder.landmarkColor;
+    this.connectionColor = builder.connectionColor;
+    this.boxColor = builder.boxColor;
+    this.textColor = builder.textColor;
+    this.textBackgroundColor = builder.textBackgroundColor;
+    this.landmarkRadius = builder.landmarkRadius;
+    this.connectionStrokeWidth = builder.connectionStrokeWidth;
+    this.boxStrokeWidth = builder.boxStrokeWidth;
+    this.textSize = builder.textSize;
+    this.textPadding = builder.textPadding;
+  }
+
+  /** Density-independent defaults (1px = 1dp). Prefer {@link #mediapipeDefault(float)}. */
+  public static OverlayStyle mediapipeDefault() {
+    return mediapipeDefault(/* density= */ 1.f);
+  }
+
+  /**
+   * Defaults scaled by display density so strokes stay readable on Compose / high-dpi screens.
+   *
+   * @param density {@code Resources.getDisplayMetrics().density} or Compose {@code
+   *     LocalDensity.current.density}
+   */
+  public static OverlayStyle mediapipeDefault(float density) {
+    if (density <= 0.f) {
+      throw new IllegalArgumentException("Density must be positive, found: " + density);
+    }
+    return builder()
+        .setLandmarkRadius(4.f * density)
+        .setConnectionStrokeWidth(4.f * density)
+        .setBoxStrokeWidth(4.f * density)
+        .setTextSize(16.f * density)
+        .setTextPadding(4.f * density)
+        .build();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public int landmarkColor() {
+    return landmarkColor;
+  }
+
+  public int connectionColor() {
+    return connectionColor;
+  }
+
+  public int boxColor() {
+    return boxColor;
+  }
+
+  public int textColor() {
+    return textColor;
+  }
+
+  public int textBackgroundColor() {
+    return textBackgroundColor;
+  }
+
+  public float landmarkRadius() {
+    return landmarkRadius;
+  }
+
+  public float connectionStrokeWidth() {
+    return connectionStrokeWidth;
+  }
+
+  public float boxStrokeWidth() {
+    return boxStrokeWidth;
+  }
+
+  public float textSize() {
+    return textSize;
+  }
+
+  public float textPadding() {
+    return textPadding;
+  }
+
+  public Builder toBuilder() {
+    return builder()
+        .setLandmarkColor(landmarkColor)
+        .setConnectionColor(connectionColor)
+        .setBoxColor(boxColor)
+        .setTextColor(textColor)
+        .setTextBackgroundColor(textBackgroundColor)
+        .setLandmarkRadius(landmarkRadius)
+        .setConnectionStrokeWidth(connectionStrokeWidth)
+        .setBoxStrokeWidth(boxStrokeWidth)
+        .setTextSize(textSize)
+        .setTextPadding(textPadding);
+  }
+
+  /** Builder for {@link OverlayStyle}. */
+  public static final class Builder {
+    private int landmarkColor = DEFAULT_LANDMARK_COLOR;
+    private int connectionColor = DEFAULT_CONNECTION_COLOR;
+    private int boxColor = DEFAULT_BOX_COLOR;
+    private int textColor = Color.WHITE;
+    private int textBackgroundColor = 0x99000000;
+    private float landmarkRadius = 4.f;
+    private float connectionStrokeWidth = 4.f;
+    private float boxStrokeWidth = 4.f;
+    private float textSize = 16.f;
+    private float textPadding = 4.f;
+
+    public Builder setLandmarkColor(int landmarkColor) {
+      this.landmarkColor = landmarkColor;
+      return this;
+    }
+
+    public Builder setConnectionColor(int connectionColor) {
+      this.connectionColor = connectionColor;
+      return this;
+    }
+
+    public Builder setBoxColor(int boxColor) {
+      this.boxColor = boxColor;
+      return this;
+    }
+
+    public Builder setTextColor(int textColor) {
+      this.textColor = textColor;
+      return this;
+    }
+
+    public Builder setTextBackgroundColor(int textBackgroundColor) {
+      this.textBackgroundColor = textBackgroundColor;
+      return this;
+    }
+
+    public Builder setLandmarkRadius(float landmarkRadius) {
+      this.landmarkRadius = requirePositive("landmarkRadius", landmarkRadius);
+      return this;
+    }
+
+    public Builder setConnectionStrokeWidth(float connectionStrokeWidth) {
+      this.connectionStrokeWidth = requirePositive("connectionStrokeWidth", connectionStrokeWidth);
+      return this;
+    }
+
+    public Builder setBoxStrokeWidth(float boxStrokeWidth) {
+      this.boxStrokeWidth = requirePositive("boxStrokeWidth", boxStrokeWidth);
+      return this;
+    }
+
+    public Builder setTextSize(float textSize) {
+      this.textSize = requirePositive("textSize", textSize);
+      return this;
+    }
+
+    public Builder setTextPadding(float textPadding) {
+      if (textPadding < 0.f) {
+        throw new IllegalArgumentException("textPadding must be >= 0, found: " + textPadding);
+      }
+      this.textPadding = textPadding;
+      return this;
+    }
+
+    public OverlayStyle build() {
+      return new OverlayStyle(this);
+    }
+
+    private static float requirePositive(String name, float value) {
+      if (value <= 0.f) {
+        throw new IllegalArgumentException(name + " must be positive, found: " + value);
+      }
+      return value;
+    }
+  }
+}

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/VisionOverlayRenderer.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/VisionOverlayRenderer.java
@@ -1,0 +1,344 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Paint.Align;
+import android.graphics.Paint.Style;
+import android.graphics.Rect;
+import com.google.mediapipe.tasks.components.containers.Category;
+import com.google.mediapipe.tasks.components.containers.Connection;
+import com.google.mediapipe.tasks.components.containers.Detection;
+import com.google.mediapipe.tasks.components.containers.NormalizedKeypoint;
+import com.google.mediapipe.tasks.components.containers.NormalizedLandmark;
+import com.google.mediapipe.tasks.vision.facedetector.FaceDetectorResult;
+import com.google.mediapipe.tasks.vision.facelandmarker.FaceLandmarker;
+import com.google.mediapipe.tasks.vision.facelandmarker.FaceLandmarkerResult;
+import com.google.mediapipe.tasks.vision.gesturerecognizer.GestureRecognizerResult;
+import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarker;
+import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarkerResult;
+import com.google.mediapipe.tasks.vision.holisticlandmarker.HolisticLandmarkerResult;
+import com.google.mediapipe.tasks.vision.objectdetector.ObjectDetectorResult;
+import com.google.mediapipe.tasks.vision.poselandmarker.PoseLandmarker;
+import com.google.mediapipe.tasks.vision.poselandmarker.PoseLandmarkerResult;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Draws MediaPipe Tasks vision results onto an {@link Canvas}.
+ *
+ * <p>Use from Jetpack Compose:
+ *
+ * <pre>{@code
+ * Canvas(Modifier.fillMaxSize()) {
+ *   val layout = OverlayLayout.create(
+ *       size.width.toInt(), size.height.toInt(),
+ *       imageWidth, imageHeight, RunningMode.LIVE_STREAM,
+ *       rotationDegrees = 0, mirrored = lensFacing == LENS_FACING_FRONT)
+ *   drawIntoCanvas { native ->
+ *     VisionOverlayRenderer.drawHands(
+ *         native.nativeCanvas, result, layout, OverlayStyle.mediapipeDefault(density.density))
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>Null or empty results are no-ops. Connection indices outside a landmark list are skipped.
+ */
+public final class VisionOverlayRenderer {
+  private VisionOverlayRenderer() {}
+
+  /** Draws {@link HandLandmarker} skeletons. */
+  public static void drawHands(
+      Canvas canvas, HandLandmarkerResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawLandmarks(canvas, result.landmarks(), HandLandmarker.HAND_CONNECTIONS, layout, style);
+  }
+
+  /** Draws {@link PoseLandmarker} skeletons. */
+  public static void drawPose(
+      Canvas canvas, PoseLandmarkerResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawLandmarks(canvas, result.landmarks(), PoseLandmarker.POSE_LANDMARKS, layout, style);
+  }
+
+  /** Draws {@link FaceLandmarker} contours (connectors, not the full tesselation). */
+  public static void drawFaceLandmarks(
+      Canvas canvas, FaceLandmarkerResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawLandmarks(
+        canvas, result.faceLandmarks(), FaceLandmarker.FACE_LANDMARKS_CONNECTORS, layout, style);
+  }
+
+  /** Draws {@link ObjectDetector} boxes and labels. */
+  public static void drawObjects(
+      Canvas canvas, ObjectDetectorResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawDetections(canvas, result.detections(), layout, style, /* drawKeypoints= */ false);
+  }
+
+  /** Draws {@link FaceDetector} boxes, labels, and keypoints. */
+  public static void drawFaceDetections(
+      Canvas canvas, FaceDetectorResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawDetections(canvas, result.detections(), layout, style, /* drawKeypoints= */ true);
+  }
+
+  /**
+   * Draws {@link GestureRecognizer} hand skeletons and the top gesture label near the wrist
+   * (landmark 0).
+   */
+  public static void drawGestures(
+      Canvas canvas, GestureRecognizerResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    drawLandmarks(canvas, result.landmarks(), HandLandmarker.HAND_CONNECTIONS, layout, style);
+    List<List<NormalizedLandmark>> hands = result.landmarks();
+    List<List<Category>> gestures = result.gestures();
+    int count = Math.min(hands.size(), gestures.size());
+    for (int i = 0; i < count; i++) {
+      List<NormalizedLandmark> hand = hands.get(i);
+      List<Category> categories = gestures.get(i);
+      if (hand.isEmpty() || categories.isEmpty()) {
+        continue;
+      }
+      drawLabel(
+          canvas,
+          layout.mapX(hand.get(0).x()),
+          layout.mapY(hand.get(0).y()),
+          formatCategory(categories.get(0)),
+          style);
+    }
+  }
+
+  /** Draws {@link HolisticLandmarker} face, pose, and both hands. */
+  public static void drawHolistic(
+      Canvas canvas, HolisticLandmarkerResult result, OverlayLayout layout, OverlayStyle style) {
+    if (result == null) {
+      return;
+    }
+    if (!result.faceLandmarks().isEmpty()) {
+      drawLandmarks(
+          canvas,
+          Collections.singletonList(result.faceLandmarks()),
+          FaceLandmarker.FACE_LANDMARKS_CONNECTORS,
+          layout,
+          style);
+    }
+    if (!result.poseLandmarks().isEmpty()) {
+      drawLandmarks(
+          canvas,
+          Collections.singletonList(result.poseLandmarks()),
+          PoseLandmarker.POSE_LANDMARKS,
+          layout,
+          style);
+    }
+    if (!result.leftHandLandmarks().isEmpty()) {
+      drawLandmarks(
+          canvas,
+          Collections.singletonList(result.leftHandLandmarks()),
+          HandLandmarker.HAND_CONNECTIONS,
+          layout,
+          style);
+    }
+    if (!result.rightHandLandmarks().isEmpty()) {
+      drawLandmarks(
+          canvas,
+          Collections.singletonList(result.rightHandLandmarks()),
+          HandLandmarker.HAND_CONNECTIONS,
+          layout,
+          style);
+    }
+  }
+
+  /**
+   * Draws one or more landmark lists and the given connections. Safe to call from Compose or a
+   * custom View.
+   */
+  public static void drawLandmarks(
+      Canvas canvas,
+      List<List<NormalizedLandmark>> multiLandmarks,
+      Set<Connection> connections,
+      OverlayLayout layout,
+      OverlayStyle style) {
+    requireDrawArgs(canvas, layout, style);
+    if (multiLandmarks == null || multiLandmarks.isEmpty()) {
+      return;
+    }
+    Paint linePaint = connectionPaint(style);
+    Paint pointPaint = landmarkPaint(style);
+    for (List<NormalizedLandmark> landmarks : multiLandmarks) {
+      if (landmarks == null || landmarks.isEmpty()) {
+        continue;
+      }
+      if (connections != null) {
+        for (Connection connection : connections) {
+          if (connection == null) {
+            continue;
+          }
+          int start = connection.start();
+          int end = connection.end();
+          if (start < 0 || end < 0 || start >= landmarks.size() || end >= landmarks.size()) {
+            continue;
+          }
+          NormalizedLandmark from = landmarks.get(start);
+          NormalizedLandmark to = landmarks.get(end);
+          canvas.drawLine(
+              layout.mapX(from.x()),
+              layout.mapY(from.y()),
+              layout.mapX(to.x()),
+              layout.mapY(to.y()),
+              linePaint);
+        }
+      }
+      for (NormalizedLandmark landmark : landmarks) {
+        canvas.drawCircle(
+            layout.mapX(landmark.x()),
+            layout.mapY(landmark.y()),
+            style.landmarkRadius(),
+            pointPaint);
+      }
+    }
+  }
+
+  /**
+   * Draws detection bounding boxes (image pixel space) and the top category label.
+   *
+   * @param drawKeypoints when {@code true}, also draws {@link Detection#keypoints()}
+   */
+  public static void drawDetections(
+      Canvas canvas,
+      List<Detection> detections,
+      OverlayLayout layout,
+      OverlayStyle style,
+      boolean drawKeypoints) {
+    requireDrawArgs(canvas, layout, style);
+    if (detections == null || detections.isEmpty()) {
+      return;
+    }
+    Paint boxPaint = boxPaint(style);
+    Paint keypointPaint = landmarkPaint(style);
+    for (Detection detection : detections) {
+      if (detection == null) {
+        continue;
+      }
+      RectF box = layout.mapImageRect(detection.boundingBox());
+      canvas.drawRect(box, boxPaint);
+      if (!detection.categories().isEmpty()) {
+        drawLabel(canvas, box.left, box.top, formatCategory(detection.categories().get(0)), style);
+      }
+      if (drawKeypoints && detection.keypoints().isPresent()) {
+        for (NormalizedKeypoint keypoint : detection.keypoints().get()) {
+          canvas.drawCircle(
+              layout.mapX(keypoint.x()),
+              layout.mapY(keypoint.y()),
+              style.landmarkRadius(),
+              keypointPaint);
+        }
+      }
+    }
+  }
+
+  static String formatCategory(Category category) {
+    String name = category.displayName();
+    if (name == null || name.isEmpty()) {
+      name = category.categoryName();
+    }
+    if (name == null) {
+      name = "";
+    }
+    return String.format(Locale.US, "%s %.2f", name, category.score());
+  }
+
+  private static void drawLabel(
+      Canvas canvas, float left, float top, String text, OverlayStyle style) {
+    Paint textPaint = textPaint(style);
+    Paint backgroundPaint = textBackgroundPaint(style);
+    Rect bounds = new Rect();
+    textPaint.getTextBounds(text, 0, text.length(), bounds);
+    float padding = style.textPadding();
+    float bgTop = top;
+    float bgBottom = top + bounds.height() + 2.f * padding;
+    float bgRight = left + bounds.width() + 2.f * padding;
+    canvas.drawRect(left, bgTop, bgRight, bgBottom, backgroundPaint);
+    // getTextBounds origin is the text baseline; pad then offset by -bounds.top.
+    canvas.drawText(text, left + padding, top + padding - bounds.top, textPaint);
+  }
+
+  private static void requireDrawArgs(Canvas canvas, OverlayLayout layout, OverlayStyle style) {
+    if (canvas == null) {
+      throw new IllegalArgumentException("Canvas must not be null");
+    }
+    if (layout == null) {
+      throw new IllegalArgumentException("OverlayLayout must not be null");
+    }
+    if (style == null) {
+      throw new IllegalArgumentException("OverlayStyle must not be null");
+    }
+  }
+
+  private static Paint landmarkPaint(OverlayStyle style) {
+    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    paint.setColor(style.landmarkColor());
+    paint.setStyle(Style.FILL);
+    return paint;
+  }
+
+  private static Paint connectionPaint(OverlayStyle style) {
+    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    paint.setColor(style.connectionColor());
+    paint.setStyle(Style.STROKE);
+    paint.setStrokeWidth(style.connectionStrokeWidth());
+    paint.setStrokeCap(Paint.Cap.ROUND);
+    return paint;
+  }
+
+  private static Paint boxPaint(OverlayStyle style) {
+    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    paint.setColor(style.boxColor());
+    paint.setStyle(Style.STROKE);
+    paint.setStrokeWidth(style.boxStrokeWidth());
+    return paint;
+  }
+
+  private static Paint textPaint(OverlayStyle style) {
+    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    paint.setColor(style.textColor());
+    paint.setStyle(Style.FILL);
+    paint.setTextSize(style.textSize());
+    paint.setTextAlign(Align.LEFT);
+    return paint;
+  }
+
+  private static Paint textBackgroundPaint(OverlayStyle style) {
+    Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    paint.setColor(style.textBackgroundColor());
+    paint.setStyle(Style.FILL);
+    return paint;
+  }
+}

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/VisionOverlayView.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/VisionOverlayView.java
@@ -1,0 +1,264 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.view.View;
+import com.google.mediapipe.tasks.vision.core.RunningMode;
+import com.google.mediapipe.tasks.vision.facedetector.FaceDetectorResult;
+import com.google.mediapipe.tasks.vision.facelandmarker.FaceLandmarkerResult;
+import com.google.mediapipe.tasks.vision.gesturerecognizer.GestureRecognizerResult;
+import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarkerResult;
+import com.google.mediapipe.tasks.vision.holisticlandmarker.HolisticLandmarkerResult;
+import com.google.mediapipe.tasks.vision.objectdetector.ObjectDetectorResult;
+import com.google.mediapipe.tasks.vision.poselandmarker.PoseLandmarkerResult;
+
+/**
+ * Transparent overlay {@link View} that draws MediaPipe Tasks vision results.
+ *
+ * <p>This is the Compose integration path that does not require a Compose dependency in
+ * {@code tasks-vision}: wrap the view with {@code AndroidView}, stacked on {@code PreviewView}.
+ *
+ * <pre>{@code
+ * Box(Modifier.fillMaxSize()) {
+ *   AndroidView(factory = { PreviewView(it) }, modifier = Modifier.fillMaxSize())
+ *   AndroidView(
+ *       factory = { VisionOverlayView(it) },
+ *       modifier = Modifier.fillMaxSize(),
+ *       update = { overlay ->
+ *         overlay.setMirrored(lensFacing == CameraSelector.LENS_FACING_FRONT)
+ *         overlay.setHandLandmarkerResult(
+ *             result, imageWidth, imageHeight, RunningMode.LIVE_STREAM)
+ *       })
+ * }
+ * }</pre>
+ *
+ * <p>{@link #setHandLandmarkerResult} and the other setters are safe to call from the MediaPipe
+ * live-stream callback thread; they {@link #postInvalidate()}.
+ */
+public final class VisionOverlayView extends View {
+  private enum Kind {
+    NONE,
+    HANDS,
+    POSE,
+    FACE_LANDMARKS,
+    OBJECTS,
+    FACE_DETECTIONS,
+    GESTURES,
+    HOLISTIC
+  }
+
+  private Kind kind = Kind.NONE;
+  private HandLandmarkerResult hands;
+  private PoseLandmarkerResult pose;
+  private FaceLandmarkerResult faceLandmarks;
+  private ObjectDetectorResult objects;
+  private FaceDetectorResult faceDetections;
+  private GestureRecognizerResult gestures;
+  private HolisticLandmarkerResult holistic;
+  private int imageWidth = 1;
+  private int imageHeight = 1;
+  private RunningMode runningMode = RunningMode.IMAGE;
+  private int rotationDegrees = 0;
+  private boolean mirrored = false;
+  private OverlayStyle style;
+
+  public VisionOverlayView(Context context) {
+    this(context, null);
+  }
+
+  public VisionOverlayView(Context context, AttributeSet attrs) {
+    this(context, attrs, 0);
+  }
+
+  public VisionOverlayView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    setWillNotDraw(false);
+    setBackgroundColor(Color.TRANSPARENT);
+    style = OverlayStyle.mediapipeDefault(context.getResources().getDisplayMetrics().density);
+  }
+
+  /** Replaces the default MediaPipe colors / sizes. */
+  public void setStyle(OverlayStyle style) {
+    if (style == null) {
+      throw new IllegalArgumentException("OverlayStyle must not be null");
+    }
+    this.style = style;
+    postInvalidate();
+  }
+
+  public OverlayStyle getStyle() {
+    return style;
+  }
+
+  /**
+   * Flip overlay X to match a mirrored front-camera preview. Default {@code false}.
+   *
+   * <p>Call this when switching cameras; it applies to the next draw of whatever result is set.
+   */
+  public void setMirrored(boolean mirrored) {
+    this.mirrored = mirrored;
+    postInvalidate();
+  }
+
+  public boolean isMirrored() {
+    return mirrored;
+  }
+
+  /**
+   * Clockwise camera-frame rotation in degrees (0/90/180/270). Used for object/face boxes in
+   * sensor orientation. Default {@code 0}.
+   */
+  public void setRotationDegrees(int rotationDegrees) {
+    this.rotationDegrees = OverlayLayout.normalizeRotation(rotationDegrees);
+    postInvalidate();
+  }
+
+  public int getRotationDegrees() {
+    return rotationDegrees;
+  }
+
+  /** Clears the current result and redraws an empty overlay. */
+  public void clear() {
+    kind = Kind.NONE;
+    hands = null;
+    pose = null;
+    faceLandmarks = null;
+    objects = null;
+    faceDetections = null;
+    gestures = null;
+    holistic = null;
+    postInvalidate();
+  }
+
+  public void setHandLandmarkerResult(
+      HandLandmarkerResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.HANDS;
+    hands = result;
+    postInvalidate();
+  }
+
+  public void setPoseLandmarkerResult(
+      PoseLandmarkerResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.POSE;
+    pose = result;
+    postInvalidate();
+  }
+
+  public void setFaceLandmarkerResult(
+      FaceLandmarkerResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.FACE_LANDMARKS;
+    faceLandmarks = result;
+    postInvalidate();
+  }
+
+  public void setObjectDetectorResult(
+      ObjectDetectorResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.OBJECTS;
+    objects = result;
+    postInvalidate();
+  }
+
+  public void setFaceDetectorResult(
+      FaceDetectorResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.FACE_DETECTIONS;
+    faceDetections = result;
+    postInvalidate();
+  }
+
+  public void setGestureRecognizerResult(
+      GestureRecognizerResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.GESTURES;
+    gestures = result;
+    postInvalidate();
+  }
+
+  public void setHolisticLandmarkerResult(
+      HolisticLandmarkerResult result, int imageWidth, int imageHeight, RunningMode runningMode) {
+    setImage(imageWidth, imageHeight, runningMode);
+    kind = Kind.HOLISTIC;
+    holistic = result;
+    postInvalidate();
+  }
+
+  @Override
+  protected void onDraw(Canvas canvas) {
+    super.onDraw(canvas);
+    int contentWidth = getWidth() - getPaddingLeft() - getPaddingRight();
+    int contentHeight = getHeight() - getPaddingTop() - getPaddingBottom();
+    if (kind == Kind.NONE || contentWidth <= 0 || contentHeight <= 0) {
+      return;
+    }
+    OverlayLayout layout =
+        OverlayLayout.create(
+            contentWidth,
+            contentHeight,
+            imageWidth,
+            imageHeight,
+            runningMode,
+            rotationDegrees,
+            mirrored);
+    canvas.save();
+    canvas.translate(getPaddingLeft(), getPaddingTop());
+    switch (kind) {
+      case HANDS:
+        VisionOverlayRenderer.drawHands(canvas, hands, layout, style);
+        break;
+      case POSE:
+        VisionOverlayRenderer.drawPose(canvas, pose, layout, style);
+        break;
+      case FACE_LANDMARKS:
+        VisionOverlayRenderer.drawFaceLandmarks(canvas, faceLandmarks, layout, style);
+        break;
+      case OBJECTS:
+        VisionOverlayRenderer.drawObjects(canvas, objects, layout, style);
+        break;
+      case FACE_DETECTIONS:
+        VisionOverlayRenderer.drawFaceDetections(canvas, faceDetections, layout, style);
+        break;
+      case GESTURES:
+        VisionOverlayRenderer.drawGestures(canvas, gestures, layout, style);
+        break;
+      case HOLISTIC:
+        VisionOverlayRenderer.drawHolistic(canvas, holistic, layout, style);
+        break;
+      case NONE:
+        break;
+    }
+    canvas.restore();
+  }
+
+  private void setImage(int imageWidth, int imageHeight, RunningMode runningMode) {
+    if (imageWidth <= 0 || imageHeight <= 0) {
+      throw new IllegalArgumentException(
+          "Image size must be positive, found: " + imageWidth + "x" + imageHeight);
+    }
+    if (runningMode == null) {
+      throw new IllegalArgumentException("RunningMode must not be null");
+    }
+    this.imageWidth = imageWidth;
+    this.imageHeight = imageHeight;
+    this.runningMode = runningMode;
+  }
+}

--- a/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/package-info.java
+++ b/mediapipe/tasks/java/com/google/mediapipe/tasks/vision/overlay/package-info.java
@@ -1,0 +1,33 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Overlay helpers so Jetpack Compose (and XML) apps can draw MediaPipe Tasks vision results on
+ * top of a camera preview or still image.
+ *
+ * <p>The Tasks AAR cannot depend on Compose without forcing Compose onto every Android client.
+ * These classes use {@link android.graphics.Canvas}, which Compose already interops with:
+ *
+ * <ul>
+ *   <li>{@link com.google.mediapipe.tasks.vision.overlay.VisionOverlayView} inside {@code
+ *       AndroidView} — same pattern as CameraX {@code PreviewView}.
+ *   <li>{@link com.google.mediapipe.tasks.vision.overlay.VisionOverlayRenderer} from a Compose
+ *       {@code Canvas} via {@code drawIntoCanvas}.
+ * </ul>
+ *
+ * <p>Scale matches the official samples: IMAGE/VIDEO use FIT_START ({@code min} scale), LIVE_STREAM
+ * uses FILL_START ({@code max} scale) so landmarks line up with CameraX {@code PreviewView} in
+ * {@code FILL_START} / {@code FILL_CENTER} for typical 4:3 models.
+ */
+package com.google.mediapipe.tasks.vision.overlay;

--- a/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/BUILD
+++ b/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/BUILD
@@ -1,0 +1,18 @@
+# Copyright 2026 The MediaPipe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+# OverlayLayoutTest, OverlayStyleTest, VisionOverlayRendererTest, VisionOverlayViewTest
+# TODO: Enable this in OSS

--- a/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/OverlayLayoutTest.java
+++ b/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/OverlayLayoutTest.java
@@ -1,0 +1,202 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.graphics.RectF;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.mediapipe.tasks.vision.core.RunningMode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link OverlayLayout} — FIT vs FILL, mirroring, and camera-frame rotation. */
+@RunWith(AndroidJUnit4.class)
+public final class OverlayLayoutTest {
+
+  @Test
+  public void liveStream_portraitPreviewOnWideCameraFrame() {
+    // Typical Phone UI 1080x1920 over a 640x480 camera frame.
+    OverlayLayout layout = OverlayLayout.create(1080, 1920, 640, 480, RunningMode.LIVE_STREAM);
+    assertThat(layout.scale()).isEqualTo(4.f);
+    assertThat(layout.mapX(0.5f)).isEqualTo(1280.f);
+    assertThat(layout.mapY(0.5f)).isEqualTo(960.f);
+  }
+
+  @Test
+  public void imageMode_fitsWithMinScale() {
+    // View 200x100, image 100x100 → min(2, 1) = 1 (letterbox, FIT_START).
+    OverlayLayout layout =
+        OverlayLayout.create(200, 100, 100, 100, RunningMode.IMAGE);
+    assertThat(layout.scale()).isEqualTo(1.f);
+    assertThat(layout.mapX(0.5f)).isEqualTo(50.f);
+    assertThat(layout.mapY(0.5f)).isEqualTo(50.f);
+  }
+
+  @Test
+  public void videoMode_matchesImageFit() {
+    OverlayLayout image = OverlayLayout.create(200, 100, 100, 100, RunningMode.IMAGE);
+    OverlayLayout video = OverlayLayout.create(200, 100, 100, 100, RunningMode.VIDEO);
+    assertThat(video.scale()).isEqualTo(image.scale());
+  }
+
+  @Test
+  public void liveStream_fillsWithMaxScale() {
+    // View 200x100, image 100x100 → max(2, 1) = 2 (crop, FILL_START / PreviewView).
+    OverlayLayout layout =
+        OverlayLayout.create(200, 100, 100, 100, RunningMode.LIVE_STREAM);
+    assertThat(layout.scale()).isEqualTo(2.f);
+    assertThat(layout.mapX(0.5f)).isEqualTo(100.f);
+    assertThat(layout.mapY(0.5f)).isEqualTo(100.f);
+  }
+
+  @Test
+  public void equalViewAndImage_scaleIsOne() {
+    OverlayLayout layout = OverlayLayout.create(128, 128, 128, 128, RunningMode.IMAGE);
+    assertThat(layout.scale()).isEqualTo(1.f);
+    assertThat(layout.mapX(0.f)).isEqualTo(0.f);
+    assertThat(layout.mapX(1.f)).isEqualTo(128.f);
+    assertThat(layout.mapY(1.f)).isEqualTo(128.f);
+  }
+
+  @Test
+  public void mirrored_flipsNormalizedX() {
+    OverlayLayout layout =
+        OverlayLayout.create(
+            100, 100, 100, 100, RunningMode.IMAGE, /* rotationDegrees= */ 0, /* mirrored= */ true);
+    assertThat(layout.mirrored()).isTrue();
+    // x=0.25 → 0.75 * 100 = 75
+    assertThat(layout.mapX(0.25f)).isEqualTo(75.f);
+    assertThat(layout.mapX(0.f)).isEqualTo(100.f);
+    assertThat(layout.mapX(1.f)).isEqualTo(0.f);
+    assertThat(layout.mapY(0.25f)).isEqualTo(25.f);
+  }
+
+  @Test
+  public void rotation90_swapsImageSizeForScale() {
+    OverlayLayout layout =
+        OverlayLayout.create(
+            200, 200, /* imageWidth= */ 100, /* imageHeight= */ 200, RunningMode.IMAGE, 90, false);
+    assertThat(layout.rotationDegrees()).isEqualTo(90);
+    assertThat(layout.rotatedImageWidth()).isEqualTo(200);
+    assertThat(layout.rotatedImageHeight()).isEqualTo(100);
+    // min(200/200, 200/100) = min(1, 2) = 1
+    assertThat(layout.scale()).isEqualTo(1.f);
+  }
+
+  @Test
+  public void rotation270_sameSwapAs90() {
+    OverlayLayout layout =
+        OverlayLayout.create(200, 200, 100, 200, RunningMode.IMAGE, 270, false);
+    assertThat(layout.rotatedImageWidth()).isEqualTo(200);
+    assertThat(layout.rotatedImageHeight()).isEqualTo(100);
+  }
+
+  @Test
+  public void negativeRotation_normalizes() {
+    OverlayLayout layout =
+        OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE, -90, false);
+    assertThat(layout.rotationDegrees()).isEqualTo(270);
+  }
+
+  @Test
+  public void rotation450_normalizesTo90() {
+    OverlayLayout layout =
+        OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE, 450, false);
+    assertThat(layout.rotationDegrees()).isEqualTo(90);
+  }
+
+  @Test
+  public void mapImageRect_noRotation_scales() {
+    OverlayLayout layout = OverlayLayout.create(200, 200, 100, 100, RunningMode.IMAGE);
+    RectF mapped = layout.mapImageRect(new RectF(10.f, 20.f, 30.f, 40.f));
+    assertThat(mapped.left).isEqualTo(20.f);
+    assertThat(mapped.top).isEqualTo(40.f);
+    assertThat(mapped.right).isEqualTo(60.f);
+    assertThat(mapped.bottom).isEqualTo(80.f);
+  }
+
+  @Test
+  public void mapImageRect_rotation180_sendsTopLeftToBottomRight() {
+    OverlayLayout layout =
+        OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE, 180, false);
+    RectF mapped = layout.mapImageRect(new RectF(0.f, 0.f, 10.f, 10.f));
+    assertThat(mapped.left).isEqualTo(90.f);
+    assertThat(mapped.top).isEqualTo(90.f);
+    assertThat(mapped.right).isEqualTo(100.f);
+    assertThat(mapped.bottom).isEqualTo(100.f);
+  }
+
+  @Test
+  public void mapImageRect_rotation90_fullFrameCoversRotatedBounds() {
+    OverlayLayout layout =
+        OverlayLayout.create(200, 100, 100, 200, RunningMode.IMAGE, 90, false);
+    RectF mapped = layout.mapImageRect(new RectF(0.f, 0.f, 100.f, 200.f));
+    assertThat(mapped.left).isEqualTo(0.f);
+    assertThat(mapped.top).isEqualTo(0.f);
+    assertThat(mapped.right).isEqualTo(200.f);
+    assertThat(mapped.bottom).isEqualTo(100.f);
+  }
+
+  @Test
+  public void mapImageRect_mirrored_flipsHorizontally() {
+    OverlayLayout layout =
+        OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE, 0, true);
+    RectF mapped = layout.mapImageRect(new RectF(0.f, 10.f, 20.f, 30.f));
+    assertThat(mapped.left).isEqualTo(80.f);
+    assertThat(mapped.right).isEqualTo(100.f);
+    assertThat(mapped.top).isEqualTo(10.f);
+    assertThat(mapped.bottom).isEqualTo(30.f);
+  }
+
+  @Test
+  public void rejectsNonPositiveViewSize() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> OverlayLayout.create(0, 100, 100, 100, RunningMode.IMAGE));
+    assertThat(thrown).hasMessageThat().contains("View size must be positive");
+  }
+
+  @Test
+  public void rejectsNonPositiveImageSize() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> OverlayLayout.create(100, 100, 100, 0, RunningMode.IMAGE));
+    assertThat(thrown).hasMessageThat().contains("Image size must be positive");
+  }
+
+  @Test
+  public void rejectsNon90MultipleRotation() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE, 45, false));
+    assertThat(thrown).hasMessageThat().contains("multiple of 90");
+  }
+
+  @Test
+  public void mapImageRect_nullBox_throws() {
+    OverlayLayout layout = OverlayLayout.create(100, 100, 100, 100, RunningMode.IMAGE);
+    assertThrows(IllegalArgumentException.class, () -> layout.mapImageRect(null));
+  }
+
+  @Test
+  public void normalizeRotation_rejectsNonMultiples() {
+    assertThrows(IllegalArgumentException.class, () -> OverlayLayout.normalizeRotation(1));
+  }
+}

--- a/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/OverlayStyleTest.java
+++ b/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/OverlayStyleTest.java
@@ -1,0 +1,80 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.graphics.Color;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link OverlayStyle}. */
+@RunWith(AndroidJUnit4.class)
+public final class OverlayStyleTest {
+
+  @Test
+  public void mediapipeDefault_scalesWithDensity() {
+    OverlayStyle mdpi = OverlayStyle.mediapipeDefault(1.f);
+    OverlayStyle xhdpi = OverlayStyle.mediapipeDefault(2.f);
+    assertThat(xhdpi.landmarkRadius()).isEqualTo(mdpi.landmarkRadius() * 2.f);
+    assertThat(xhdpi.connectionStrokeWidth()).isEqualTo(mdpi.connectionStrokeWidth() * 2.f);
+    assertThat(xhdpi.textSize()).isEqualTo(mdpi.textSize() * 2.f);
+    assertThat(xhdpi.boxStrokeWidth()).isEqualTo(mdpi.boxStrokeWidth() * 2.f);
+  }
+
+  @Test
+  public void mediapipeDefault_rejectsNonPositiveDensity() {
+    assertThrows(IllegalArgumentException.class, () -> OverlayStyle.mediapipeDefault(0.f));
+    assertThrows(IllegalArgumentException.class, () -> OverlayStyle.mediapipeDefault(-1.f));
+  }
+
+  @Test
+  public void builder_rejectsNonPositiveRadius() {
+    assertThrows(
+        IllegalArgumentException.class, () -> OverlayStyle.builder().setLandmarkRadius(0.f));
+  }
+
+  @Test
+  public void builder_rejectsNegativePadding() {
+    assertThrows(
+        IllegalArgumentException.class, () -> OverlayStyle.builder().setTextPadding(-1.f));
+  }
+
+  @Test
+  public void toBuilder_roundTrips() {
+    OverlayStyle original =
+        OverlayStyle.builder()
+            .setLandmarkColor(Color.RED)
+            .setConnectionColor(Color.BLUE)
+            .setBoxColor(Color.GREEN)
+            .setTextSize(12.f)
+            .build();
+    OverlayStyle copy = original.toBuilder().build();
+    assertThat(copy.landmarkColor()).isEqualTo(Color.RED);
+    assertThat(copy.connectionColor()).isEqualTo(Color.BLUE);
+    assertThat(copy.boxColor()).isEqualTo(Color.GREEN);
+    assertThat(copy.textSize()).isEqualTo(12.f);
+  }
+
+  @Test
+  public void defaultColors_areOpaque() {
+    OverlayStyle style = OverlayStyle.mediapipeDefault();
+    assertThat(Color.alpha(style.landmarkColor())).isEqualTo(255);
+    assertThat(Color.alpha(style.connectionColor())).isEqualTo(255);
+    assertThat(Color.alpha(style.boxColor())).isEqualTo(255);
+  }
+}

--- a/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/VisionOverlayRendererTest.java
+++ b/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/VisionOverlayRendererTest.java
@@ -1,0 +1,321 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.RectF;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.mediapipe.tasks.components.containers.Category;
+import com.google.mediapipe.tasks.components.containers.Connection;
+import com.google.mediapipe.tasks.components.containers.Detection;
+import com.google.mediapipe.tasks.components.containers.NormalizedKeypoint;
+import com.google.mediapipe.tasks.components.containers.NormalizedLandmark;
+import com.google.mediapipe.tasks.vision.core.RunningMode;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link VisionOverlayRenderer} drawing onto a bitmap. */
+@RunWith(AndroidJUnit4.class)
+public final class VisionOverlayRendererTest {
+
+  private static final int SIZE = 100;
+  private static final OverlayLayout LAYOUT =
+      OverlayLayout.create(SIZE, SIZE, SIZE, SIZE, RunningMode.IMAGE);
+
+  @Test
+  public void drawLandmarks_nullConnections_stillDrawsPoints() {
+    OverlayStyle style =
+        OverlayStyle.builder().setLandmarkColor(Color.RED).setLandmarkRadius(12.f).build();
+    Bitmap bitmap = emptyBitmap();
+    List<List<NormalizedLandmark>> landmarks =
+        Collections.singletonList(
+            Collections.singletonList(NormalizedLandmark.create(0.5f, 0.5f, 0.f)));
+
+    VisionOverlayRenderer.drawLandmarks(
+        new Canvas(bitmap), landmarks, /* connections= */ null, LAYOUT, style);
+
+    assertPixelCloseTo(bitmap, 50, 50, Color.RED);
+  }
+
+  @Test
+  public void drawLandmarks_paintsCenterPixel() {
+    OverlayStyle style =
+        OverlayStyle.builder().setLandmarkColor(Color.RED).setLandmarkRadius(12.f).build();
+    Bitmap bitmap = emptyBitmap();
+    List<List<NormalizedLandmark>> landmarks =
+        Collections.singletonList(
+            Collections.singletonList(NormalizedLandmark.create(0.5f, 0.5f, 0.f)));
+
+    VisionOverlayRenderer.drawLandmarks(
+        new Canvas(bitmap), landmarks, Collections.emptySet(), LAYOUT, style);
+
+    assertPixelCloseTo(bitmap, 50, 50, Color.RED);
+  }
+
+  @Test
+  public void drawLandmarks_drawsConnectionAcrossMidline() {
+    OverlayStyle style =
+        OverlayStyle.builder()
+            .setConnectionColor(Color.BLUE)
+            .setConnectionStrokeWidth(8.f)
+            .setLandmarkRadius(1.f)
+            .setLandmarkColor(Color.TRANSPARENT)
+            .build();
+    Bitmap bitmap = emptyBitmap();
+    List<NormalizedLandmark> pair =
+        Arrays.asList(
+            NormalizedLandmark.create(0.1f, 0.5f, 0.f), NormalizedLandmark.create(0.9f, 0.5f, 0.f));
+    Set<Connection> connections = Collections.singleton(Connection.create(0, 1));
+
+    VisionOverlayRenderer.drawLandmarks(
+        new Canvas(bitmap), Collections.singletonList(pair), connections, LAYOUT, style);
+
+    assertPixelCloseTo(bitmap, 50, 50, Color.BLUE);
+  }
+
+  @Test
+  public void drawLandmarks_skipsOutOfRangeConnections() {
+    OverlayStyle style =
+        OverlayStyle.builder().setLandmarkColor(Color.RED).setLandmarkRadius(10.f).build();
+    Bitmap bitmap = emptyBitmap();
+    List<NormalizedLandmark> one = Collections.singletonList(NormalizedLandmark.create(0.5f, 0.5f, 0.f));
+    Set<Connection> bad = new HashSet<>(Arrays.asList(Connection.create(0, 99), Connection.create(-1, 0)));
+
+    VisionOverlayRenderer.drawLandmarks(
+        new Canvas(bitmap), Collections.singletonList(one), bad, LAYOUT, style);
+
+    assertPixelCloseTo(bitmap, 50, 50, Color.RED);
+  }
+
+  @Test
+  public void drawLandmarks_emptyAndNull_areNoOps() {
+    OverlayStyle style = OverlayStyle.mediapipeDefault();
+    Bitmap bitmap = emptyBitmap();
+    Canvas canvas = new Canvas(bitmap);
+
+    VisionOverlayRenderer.drawLandmarks(canvas, null, Collections.emptySet(), LAYOUT, style);
+    VisionOverlayRenderer.drawLandmarks(
+        canvas, Collections.emptyList(), Collections.emptySet(), LAYOUT, style);
+    VisionOverlayRenderer.drawLandmarks(
+        canvas,
+        Collections.singletonList(Collections.emptyList()),
+        Collections.emptySet(),
+        LAYOUT,
+        style);
+
+    assertThat(bitmap.getPixel(50, 50)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawFaceDetections_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawFaceDetections(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawGestures_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawGestures(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawHolistic_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawHolistic(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawHands_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawHands(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawPose_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawPose(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawFaceLandmarks_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawFaceLandmarks(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawObjects_nullResult_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawObjects(
+        new Canvas(bitmap), null, LAYOUT, OverlayStyle.mediapipeDefault());
+    assertThat(bitmap.getPixel(0, 0)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void drawDetections_strokesBox() {
+    OverlayStyle style =
+        OverlayStyle.builder().setBoxColor(Color.GREEN).setBoxStrokeWidth(4.f).build();
+    Bitmap bitmap = emptyBitmap();
+    Detection detection =
+        Detection.create(
+            Collections.singletonList(Category.create(0.9f, 0, "person", "")),
+            new RectF(10.f, 10.f, 90.f, 90.f));
+
+    VisionOverlayRenderer.drawDetections(
+        new Canvas(bitmap),
+        Collections.singletonList(detection),
+        LAYOUT,
+        style,
+        /* drawKeypoints= */ false);
+
+    // Right edge, away from the label drawn at the top-left of the box.
+    assertPixelCloseTo(bitmap, 90, 50, Color.GREEN);
+  }
+
+  @Test
+  public void drawDetections_drawsKeypointsWhenRequested() {
+    OverlayStyle style =
+        OverlayStyle.builder().setLandmarkColor(Color.MAGENTA).setLandmarkRadius(8.f).build();
+    Bitmap bitmap = emptyBitmap();
+    Detection detection =
+        Detection.create(
+            Collections.singletonList(Category.create(1.f, 0, "face", "Face")),
+            new RectF(0.f, 0.f, 10.f, 10.f),
+            Optional.of(
+                Collections.singletonList(NormalizedKeypoint.create(0.5f, 0.5f))));
+
+    VisionOverlayRenderer.drawDetections(
+        new Canvas(bitmap), Collections.singletonList(detection), LAYOUT, style, true);
+
+    assertPixelCloseTo(bitmap, 50, 50, Color.MAGENTA);
+  }
+
+  @Test
+  public void drawDetections_empty_isNoOp() {
+    Bitmap bitmap = emptyBitmap();
+    VisionOverlayRenderer.drawDetections(
+        new Canvas(bitmap),
+        Collections.emptyList(),
+        LAYOUT,
+        OverlayStyle.mediapipeDefault(),
+        false);
+    assertThat(bitmap.getPixel(50, 50)).isEqualTo(Color.TRANSPARENT);
+  }
+
+  @Test
+  public void formatCategory_prefersDisplayName() {
+    Category category = Category.create(0.875f, 1, "person", "Person");
+    assertThat(VisionOverlayRenderer.formatCategory(category)).isEqualTo("Person 0.88");
+  }
+
+  @Test
+  public void formatCategory_fallsBackToCategoryName() {
+    Category category = Category.create(1.f, 0, "dog", "");
+    assertThat(VisionOverlayRenderer.formatCategory(category)).isEqualTo("dog 1.00");
+  }
+
+  @Test
+  public void rejectsNullCanvas() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            VisionOverlayRenderer.drawLandmarks(
+                null,
+                Collections.emptyList(),
+                Collections.emptySet(),
+                LAYOUT,
+                OverlayStyle.mediapipeDefault()));
+  }
+
+  @Test
+  public void rejectsNullLayout() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            VisionOverlayRenderer.drawLandmarks(
+                new Canvas(emptyBitmap()),
+                Collections.emptyList(),
+                Collections.emptySet(),
+                null,
+                OverlayStyle.mediapipeDefault()));
+  }
+
+  @Test
+  public void rejectsNullStyle() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            VisionOverlayRenderer.drawLandmarks(
+                new Canvas(emptyBitmap()),
+                Collections.emptyList(),
+                Collections.emptySet(),
+                LAYOUT,
+                null));
+  }
+
+  @Test
+  public void mirroredLayout_drawsLandmarkOnTheRight() {
+    OverlayLayout mirrored =
+        OverlayLayout.create(SIZE, SIZE, SIZE, SIZE, RunningMode.IMAGE, 0, true);
+    OverlayStyle style =
+        OverlayStyle.builder().setLandmarkColor(Color.RED).setLandmarkRadius(10.f).build();
+    Bitmap bitmap = emptyBitmap();
+    // x=0.25 mirrors to 0.75 → pixel 75
+    List<List<NormalizedLandmark>> landmarks =
+        Collections.singletonList(
+            Collections.singletonList(NormalizedLandmark.create(0.25f, 0.5f, 0.f)));
+
+    VisionOverlayRenderer.drawLandmarks(
+        new Canvas(bitmap), landmarks, Collections.emptySet(), mirrored, style);
+
+    assertPixelCloseTo(bitmap, 75, 50, Color.RED);
+  }
+
+  private static Bitmap emptyBitmap() {
+    Bitmap bitmap = Bitmap.createBitmap(SIZE, SIZE, Bitmap.Config.ARGB_8888);
+    bitmap.eraseColor(Color.TRANSPARENT);
+    return bitmap;
+  }
+
+  private static void assertPixelCloseTo(Bitmap bitmap, int x, int y, int expected) {
+    int pixel = bitmap.getPixel(x, y);
+    assertThat(Math.abs(Color.red(pixel) - Color.red(expected))).isLessThan(40);
+    assertThat(Math.abs(Color.green(pixel) - Color.green(expected))).isLessThan(40);
+    assertThat(Math.abs(Color.blue(pixel) - Color.blue(expected))).isLessThan(40);
+    assertThat(Color.alpha(pixel)).isGreaterThan(32);
+  }
+}

--- a/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/VisionOverlayViewTest.java
+++ b/mediapipe/tasks/javatests/com/google/mediapipe/tasks/vision/overlay/VisionOverlayViewTest.java
@@ -1,0 +1,95 @@
+// Copyright 2026 The MediaPipe Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.mediapipe.tasks.vision.overlay;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.mediapipe.tasks.vision.core.RunningMode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for {@link VisionOverlayView} setters used from Compose {@code AndroidView}. */
+@RunWith(AndroidJUnit4.class)
+public final class VisionOverlayViewTest {
+
+  @Test
+  public void constructsWithTransparentBackground() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    assertThat(view.isMirrored()).isFalse();
+    assertThat(view.getRotationDegrees()).isEqualTo(0);
+    assertThat(view.getStyle()).isNotNull();
+  }
+
+  @Test
+  public void setMirrored_roundTrips() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    view.setMirrored(true);
+    assertThat(view.isMirrored()).isTrue();
+  }
+
+  @Test
+  public void setRotationDegrees_normalizes() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    view.setRotationDegrees(-90);
+    assertThat(view.getRotationDegrees()).isEqualTo(270);
+  }
+
+  @Test
+  public void setHandLandmarkerResult_rejectsNonPositiveImageSize() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> view.setHandLandmarkerResult(null, 0, 100, RunningMode.LIVE_STREAM));
+    assertThat(thrown).hasMessageThat().contains("Image size must be positive");
+  }
+
+  @Test
+  public void setHandLandmarkerResult_rejectsNullRunningMode() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> view.setHandLandmarkerResult(null, 100, 100, null));
+  }
+
+  @Test
+  public void setStyle_rejectsNull() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    assertThrows(IllegalArgumentException.class, () -> view.setStyle(null));
+  }
+
+  @Test
+  public void clear_andNullResult_doNotThrow() {
+    VisionOverlayView view =
+        new VisionOverlayView(ApplicationProvider.getApplicationContext());
+    view.setHandLandmarkerResult(null, 128, 128, RunningMode.IMAGE);
+    view.setPoseLandmarkerResult(null, 128, 128, RunningMode.VIDEO);
+    view.setFaceLandmarkerResult(null, 128, 128, RunningMode.IMAGE);
+    view.setObjectDetectorResult(null, 128, 128, RunningMode.LIVE_STREAM);
+    view.setFaceDetectorResult(null, 128, 128, RunningMode.IMAGE);
+    view.setGestureRecognizerResult(null, 128, 128, RunningMode.IMAGE);
+    view.setHolisticLandmarkerResult(null, 128, 128, RunningMode.IMAGE);
+    view.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Jetpack Compose apps have no supported way to **display** MediaPipe Tasks results. Every official sample copies a View-based `OverlayView.kt`, and the Tasks AAR itself has no overlay API. The legacy `SolutionGlSurfaceView` path does not exist on FaceLandmarker / HandLandmarker / ObjectDetector.

This adds `com.google.mediapipe.tasks.vision.overlay` to **`tasks-vision`**. It does **not** depend on Compose, so XML apps are unchanged. Compose apps use either:

1. **`VisionOverlayView` inside `AndroidView`** (same pattern as CameraX `PreviewView`)
2. **`VisionOverlayRenderer` from a Compose `Canvas`** via `drawIntoCanvas`

@schmidt-sebastian noted this was a good library fit but the team did not have bandwidth. This is that library surface.

Fixes #5269

## What ships

| Class | Role |
|---|---|
| `OverlayLayout` | Maps normalized landmarks / image-pixel boxes onto the overlay. IMAGE/VIDEO = FIT_START (`min` scale). LIVE_STREAM = FILL_START (`max` scale) so landmarks line up with CameraX `PreviewView`. Optional front-camera `mirrored` (`x' = 1 - x`) and 0/90/180/270 box rotation. |
| `OverlayStyle` | Colors + stroke sizes. `mediapipeDefault(density)` scales for Compose `LocalDensity` / `DisplayMetrics`. |
| `VisionOverlayRenderer` | Draws hands, pose, face landmarks, objects, face detections, gestures, holistic onto any `android.graphics.Canvas`. Null/empty results are no-ops. Out-of-range connections are skipped. |
| `VisionOverlayView` | Transparent `View` for Compose `AndroidView`. Setters are safe from the live-stream callback thread (`postInvalidate()`). |

## Compose usage (AndroidView — recommended)

```kotlin
Box(Modifier.fillMaxSize()) {
  AndroidView(factory = { PreviewView(it) }, modifier = Modifier.fillMaxSize())
  AndroidView(
    factory = { VisionOverlayView(it) },
    modifier = Modifier.fillMaxSize(),
    update = { overlay ->
      overlay.setMirrored(lensFacing == CameraSelector.LENS_FACING_FRONT)
      overlay.setHandLandmarkerResult(
          result, imageWidth, imageHeight, RunningMode.LIVE_STREAM)
    })
}
```

Also: `setPoseLandmarkerResult`, `setFaceLandmarkerResult`, `setObjectDetectorResult`, `setFaceDetectorResult`, `setGestureRecognizerResult`, `setHolisticLandmarkerResult`.

## Compose usage (pure Canvas)

```kotlin
Canvas(Modifier.fillMaxSize()) {
  val layout = OverlayLayout.create(
      size.width.toInt(), size.height.toInt(),
      imageWidth, imageHeight, RunningMode.LIVE_STREAM,
      /* rotationDegrees= */ 0,
      /* mirrored= */ lensFacing == LENS_FACING_FRONT)
  drawIntoCanvas { native ->
    VisionOverlayRenderer.drawHands(
        native.nativeCanvas, result, layout,
        OverlayStyle.mediapipeDefault(density.density))
  }
}
```

## Tests

Android JUnit4 tests in `tasks/javatests/.../overlay/` (same OSS-enable TODO as the other Tasks Java tests):

- **OverlayLayoutTest** — FIT vs FILL, 1080x1920 / 640x480 live-stream scale, front-camera mirror, 90/180/270 box rotation, invalid sizes/rotations
- **OverlayStyleTest** — density scaling, builder validation, round-trip
- **VisionOverlayRendererTest** — bitmap pixel checks for landmarks, connections, boxes, keypoints, mirrored X; null/empty no-ops; out-of-range connections skipped; `Locale.US` labels
- **VisionOverlayViewTest** — constructors, mirror/rotation setters, image-size validation, null results / `clear()` from Compose `update {}`

## Why not a Compose artifact?

`tasks-vision` is Java and has no Compose compiler / maven artifacts. Putting Compose on the AAR would force Compose onto every Android client. Canvas is the Compose interop that CameraX and Maps already use, so this is the library-shaped fix Schmidt described.

## Test plan

- [x] Unit tests listed above (layout math, bitmap drawing, View setters)
- [ ] `bazel test` of Tasks Java overlay tests once OSS Robolectric is enabled (same TODO as neighboring packages)
- [ ] Manual: Compose `Box` + `PreviewView` + `VisionOverlayView`, front and back camera, IMAGE vs LIVE_STREAM
- [ ] Manual: `drawIntoCanvas` path for HandLandmarker and ObjectDetector

@schmidt-sebastian @HarishPermal @kuaashish @tyrmullen @kalyan2789g @akashvverma1995 @ayushgdev