### PR TITLE
Expose per-landmark presence scores on Web

### DIFF
--- a/mediapipe/tasks/web/components/containers/landmark.d.ts
+++ b/mediapipe/tasks/web/components/containers/landmark.d.ts
@@ -33,6 +33,12 @@ export declare interface NormalizedLandmark {
 
   /** The likelihood of the landmark being visible within the image. */
   visibility: number;
+
+  /**
+   * The likelihood of the landmark being present in the scene (within image
+   * bounds). Unset when the model does not output a presence score.
+   */
+  presence?: number;
 }
 
 /**
@@ -52,4 +58,10 @@ export declare interface Landmark {
 
   /** The likelihood of the landmark being visible within the image. */
   visibility: number;
+
+  /**
+   * The likelihood of the landmark being present in the scene (within image
+   * bounds). Unset when the model does not output a presence score.
+   */
+  presence?: number;
 }

--- a/mediapipe/tasks/web/components/processors/landmark_result.ts
+++ b/mediapipe/tasks/web/components/processors/landmark_result.ts
@@ -17,6 +17,15 @@
 import {LandmarkList as LandmarkListProto, NormalizedLandmarkList as NormalizedLandmarkListProto} from '../../../../framework/formats/landmark_pb';
 import {Landmark, NormalizedLandmark} from '../../../../tasks/web/components/containers/landmark';
 
+function copyPresence(from: {
+  hasPresence: () => boolean;
+  getPresence: () => number | undefined;
+}): {presence?: number} {
+  // Presence is proto2-optional. Keep it unset when the model does not emit
+  // a score so callers can distinguish "unsupported" from "present = 0".
+  return from.hasPresence() ? {presence: from.getPresence() ?? 0} : {};
+}
+
 /** Converts raw data into a landmark. */
 export function convertToLandmarks(proto: NormalizedLandmarkListProto):
     NormalizedLandmark[] {
@@ -27,6 +36,7 @@ export function convertToLandmarks(proto: NormalizedLandmarkListProto):
       y: landmark.getY() ?? 0,
       z: landmark.getZ() ?? 0,
       visibility: landmark.getVisibility() ?? 0,
+      ...copyPresence(landmark),
     });
   }
   return landmarks;
@@ -41,6 +51,7 @@ export function convertToWorldLandmarks(proto: LandmarkListProto): Landmark[] {
       y: worldLandmark.getY() ?? 0,
       z: worldLandmark.getZ() ?? 0,
       visibility: worldLandmark.getVisibility() ?? 0,
+      ...copyPresence(worldLandmark),
     });
   }
   return worldLandmarks;

--- a/mediapipe/tasks/web/components/processors/landmark_result_test.ts
+++ b/mediapipe/tasks/web/components/processors/landmark_result_test.ts
@@ -35,6 +35,20 @@ describe('convertToLandmarks()', () => {
     const result = convertToLandmarks(landmarkListProto);
     expect(result).toEqual([{x: 0, y: 0, z: 0, visibility: 0}]);
   });
+
+  it('copies presence when the proto field is set', () => {
+    const landmarkListProto = createLandmarks(
+        0.1, 0.2, 0.3, /* visibility= */ 0.8, /* presence= */ 0.9);
+    const result = convertToLandmarks(landmarkListProto);
+    expect(result).toEqual(
+        [{x: 0.1, y: 0.2, z: 0.3, visibility: 0.8, presence: 0.9}]);
+  });
+
+  it('omits presence when the proto field is unset', () => {
+    const landmarkListProto = createLandmarks(0.1, 0.2, 0.3);
+    const result = convertToLandmarks(landmarkListProto);
+    expect(result[0].presence).toBeUndefined();
+  });
 });
 
 describe('convertToWorldLandmarks()', () => {
@@ -48,5 +62,13 @@ describe('convertToWorldLandmarks()', () => {
     const worldLandmarkListProto = createWorldLandmarks();
     const result = convertToWorldLandmarks(worldLandmarkListProto);
     expect(result).toEqual([{x: 0, y: 0, z: 0, visibility: 0}]);
+  });
+
+  it('copies presence when the proto field is set', () => {
+    const worldLandmarkListProto = createWorldLandmarks(
+        10, 20, 30, /* visibility= */ 0.4, /* presence= */ 0.6);
+    const result = convertToWorldLandmarks(worldLandmarkListProto);
+    expect(result).toEqual(
+        [{x: 10, y: 20, z: 30, visibility: 0.4, presence: 0.6}]);
   });
 });

--- a/mediapipe/tasks/web/components/processors/landmark_result_test_lib.ts
+++ b/mediapipe/tasks/web/components/processors/landmark_result_test_lib.ts
@@ -19,26 +19,32 @@ import {Landmark as LandmarkProto, LandmarkList as LandmarkListProto, Normalized
 // The OSS JS API does not support the builder pattern.
 // tslint:disable:jspb-use-builder-pattern
 
-/** Creates a normalized landmark list with one entrry. */
+/** Creates a normalized landmark list with one entry. */
 export function createLandmarks(
-    x?: number, y?: number, z?: number): NormalizedLandmarkListProto {
+    x?: number, y?: number, z?: number, visibility?: number,
+    presence?: number): NormalizedLandmarkListProto {
   const landmarksProto = new NormalizedLandmarkListProto();
   const landmark = new NormalizedLandmarkProto();
   if (x !== undefined) landmark.setX(x);
   if (y !== undefined) landmark.setY(y);
   if (z !== undefined) landmark.setZ(z);
+  if (visibility !== undefined) landmark.setVisibility(visibility);
+  if (presence !== undefined) landmark.setPresence(presence);
   landmarksProto.addLandmark(landmark);
   return landmarksProto;
 }
 
 /** Creates a world landmark list with one entry. */
 export function createWorldLandmarks(
-    x?: number, y?: number, z?: number): LandmarkListProto {
+    x?: number, y?: number, z?: number, visibility?: number,
+    presence?: number): LandmarkListProto {
   const worldLandmarksProto = new LandmarkListProto();
   const landmark = new LandmarkProto();
   if (x !== undefined) landmark.setX(x);
   if (y !== undefined) landmark.setY(y);
   if (z !== undefined) landmark.setZ(z);
+  if (visibility !== undefined) landmark.setVisibility(visibility);
+  if (presence !== undefined) landmark.setPresence(presence);
   worldLandmarksProto.addLandmark(landmark);
   return worldLandmarksProto;
 }

--- a/mediapipe/tasks/web/vision/gesture_recognizer/BUILD
+++ b/mediapipe/tasks/web/vision/gesture_recognizer/BUILD
@@ -31,6 +31,7 @@ ts_library(
         "//mediapipe/tasks/web/components/containers:category",
         "//mediapipe/tasks/web/components/containers:landmark",
         "//mediapipe/tasks/web/components/processors:classifier_options",
+        "//mediapipe/tasks/web/components/processors:landmark_result",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:classifier_options",
         "//mediapipe/tasks/web/vision/core:image_processing_options",

--- a/mediapipe/tasks/web/vision/gesture_recognizer/gesture_recognizer.ts
+++ b/mediapipe/tasks/web/vision/gesture_recognizer/gesture_recognizer.ts
@@ -34,6 +34,10 @@ import {
   NormalizedLandmark,
 } from '../../../../tasks/web/components/containers/landmark';
 import {convertClassifierOptionsToProto} from '../../../../tasks/web/components/processors/classifier_options';
+import {
+  convertToLandmarks,
+  convertToWorldLandmarks,
+} from '../../../../tasks/web/components/processors/landmark_result';
 import {WasmFileset} from '../../../../tasks/web/core/wasm_fileset';
 import {ImageProcessingOptions} from '../../../../tasks/web/vision/core/image_processing_options';
 import {
@@ -383,16 +387,7 @@ export class GestureRecognizer extends VisionTaskRunner {
     for (const binaryProto of data) {
       const handLandmarksProto =
         NormalizedLandmarkList.deserializeBinary(binaryProto);
-      const landmarks: NormalizedLandmark[] = [];
-      for (const handLandmarkProto of handLandmarksProto.getLandmarkList()) {
-        landmarks.push({
-          x: handLandmarkProto.getX() ?? 0,
-          y: handLandmarkProto.getY() ?? 0,
-          z: handLandmarkProto.getZ() ?? 0,
-          visibility: handLandmarkProto.getVisibility() ?? 0,
-        });
-      }
-      this.landmarks.push(landmarks);
+      this.landmarks.push(convertToLandmarks(handLandmarksProto));
     }
   }
 
@@ -404,16 +399,9 @@ export class GestureRecognizer extends VisionTaskRunner {
     for (const binaryProto of data) {
       const handWorldLandmarksProto =
         LandmarkList.deserializeBinary(binaryProto);
-      const worldLandmarks: Landmark[] = [];
-      for (const handWorldLandmarkProto of handWorldLandmarksProto.getLandmarkList()) {
-        worldLandmarks.push({
-          x: handWorldLandmarkProto.getX() ?? 0,
-          y: handWorldLandmarkProto.getY() ?? 0,
-          z: handWorldLandmarkProto.getZ() ?? 0,
-          visibility: handWorldLandmarkProto.getVisibility() ?? 0,
-        });
-      }
-      this.worldLandmarks.push(worldLandmarks);
+      this.worldLandmarks.push(
+        convertToWorldLandmarks(handWorldLandmarksProto),
+      );
     }
   }
 

--- a/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker_test.ts
+++ b/mediapipe/tasks/web/vision/pose_landmarker/pose_landmarker_test.ts
@@ -390,4 +390,33 @@ describe('PoseLandmarker', () => {
     ]);
     result.close();
   });
+
+  it('returns presence scores when the proto sets them', () => {
+    const landmarksProto = [
+      createLandmarks(0.1, 0.2, 0.3, 0.7, 0.9).serializeBinary(),
+    ];
+    const worldLandmarksProto = [
+      createWorldLandmarks(1, 2, 3, 0.6, 0.8).serializeBinary(),
+    ];
+
+    poseLandmarker.fakeWasmModule._waitUntilIdle.and.callFake(() => {
+      poseLandmarker.listeners.get('normalized_landmarks')!(
+        landmarksProto,
+        1337,
+      );
+      poseLandmarker.listeners.get('world_landmarks')!(
+        worldLandmarksProto,
+        1337,
+      );
+    });
+
+    const result = poseLandmarker.detect({} as HTMLImageElement);
+    expect(result.landmarks).toEqual([
+      [{'x': 0.1, 'y': 0.2, 'z': 0.3, 'visibility': 0.7, 'presence': 0.9}],
+    ]);
+    expect(result.worldLandmarks).toEqual([
+      [{'x': 1, 'y': 2, 'z': 3, 'visibility': 0.6, 'presence': 0.8}],
+    ]);
+    result.close();
+  });
 });


### PR DESCRIPTION
## Summary

Python / Java / iOS `Landmark` already has `presence`. The Web converter only copied `x/y/z/visibility`, so PoseLandmarker (and Face / Hand / Holistic / Gesture, which share the same helper) could not implement per-keypoint filters or smoothing.

`presence` is proto2-optional and stays **unset** when the model does not emit it, matching Python (`Optional[float]`).

Fixes #5967

## API

```ts
interface NormalizedLandmark {
  x: number;
  y: number;
  z: number;
  visibility: number;
  presence?: number;  // new
}

const leftWrist = result.landmarks[0][15];
if ((leftWrist.presence ?? 0) < 0.5) {
  // drop / interpolate this keypoint
}
```

## Test plan

- [x] `landmark_result_test.ts`: copies presence when set; omits it when unset
- [x] `pose_landmarker_test.ts`: detect() returns presence on landmarks and worldLandmarks
- [ ] `bazel test //mediapipe/tasks/web/components/processors:landmark_result_test //mediapipe/tasks/web/vision/pose_landmarker:pose_landmarker_test`

@tyrmullen @kuaashish @schmidt-sebastian @HarishPermal @kalyan2789g @akashvverma1995 @ayushgdev @lu-wang-g