### PR TITLE
Add FaceLandmarker.reset() for multi-video reuse

### DIFF
--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.cc
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.cc
@@ -204,6 +204,10 @@ absl::Status CppFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker) {
   return absl::OkStatus();
 }
 
+absl::Status CppFaceLandmarkerReset(MpFaceLandmarkerPtr landmarker) {
+  return GetCppLandmarker(landmarker)->Reset();
+}
+
 }  // namespace mediapipe::tasks::c::vision::face_landmarker
 
 extern "C" {
@@ -256,6 +260,14 @@ MpStatus MpFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker,
                                char** error_msg) {
   absl::Status status =
       mediapipe::tasks::c::vision::face_landmarker::CppFaceLandmarkerClose(
+          landmarker);
+  return mediapipe::tasks::c::core::HandleStatus(status, error_msg);
+}
+
+MpStatus MpFaceLandmarkerReset(MpFaceLandmarkerPtr landmarker,
+                               char** error_msg) {
+  absl::Status status =
+      mediapipe::tasks::c::vision::face_landmarker::CppFaceLandmarkerReset(
           landmarker);
   return mediapipe::tasks::c::core::HandleStatus(status, error_msg);
 }

--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.h
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.h
@@ -173,6 +173,18 @@ MP_EXPORT void MpFaceLandmarkerCloseResult(MpFaceLandmarkerResult* result);
 MP_EXPORT MpStatus MpFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker,
                                          char** error_msg);
 
+// Resets the FaceLandmarker so it can process a new video or live stream
+// starting at any timestamp. Restarts the underlying graph (clearing tracker
+// state and the monotonic timestamp clock) without reloading the model.
+// Only needed in VIDEO or LIVE_STREAM running mode.
+//
+// Returns `kMpOk` on success. To obtain a detailed error, error_msg must be
+// non-null pointer to a char*, which will be populated with a newly-allocated
+// error message upon failure. It's the caller responsibility to free the error
+// message with MpErrorFree().
+MP_EXPORT MpStatus MpFaceLandmarkerReset(MpFaceLandmarkerPtr landmarker,
+                                         char** error_msg);
+
 #ifdef __cplusplus
 }  // extern C
 #endif

--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker_test.cc
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker_test.cc
@@ -242,6 +242,54 @@ TEST(FaceLandmarkerTest, VideoModeTest) {
   EXPECT_EQ(MpFaceLandmarkerClose(landmarker, /* error_msg= */ nullptr), kMpOk);
 }
 
+TEST(FaceLandmarkerTest, ResetAllowsNewVideoAfterReset) {
+  const auto image = GetImage(GetFullPath(kImageFile));
+  const std::string model_path = GetFullPath(kModelName);
+  MpFaceLandmarkerOptions options = {
+      /* base_options= */ {/* model_asset_buffer= */ nullptr,
+                           /* model_asset_buffer_count= */ 0,
+                           /* model_asset_path= */ model_path.c_str()},
+      /* running_mode= */ MpRunningMode::MP_RUNNING_MODE_VIDEO,
+      /* num_faces= */ 1,
+      /* min_face_detection_confidence= */ 0.5,
+      /* min_face_presence_confidence= */ 0.5,
+      /* min_tracking_confidence= */ 0.5,
+      /* output_face_blendshapes = */ false,
+      /* output_facial_transformation_matrixes = */ false,
+  };
+
+  MpFaceLandmarkerPtr landmarker;
+  ASSERT_EQ(
+      MpFaceLandmarkerCreate(&options, &landmarker, /* error_msg= */ nullptr),
+      kMpOk);
+
+  MpFaceLandmarkerResult result;
+  ASSERT_EQ(
+      MpFaceLandmarkerDetectForVideo(landmarker, image.get(),
+                                     /* image_processing_options= */ nullptr, 1,
+                                     &result, /* error_msg= */ nullptr),
+      kMpOk);
+  MpFaceLandmarkerCloseResult(&result);
+
+  char* error_msg = nullptr;
+  EXPECT_EQ(
+      MpFaceLandmarkerDetectForVideo(landmarker, image.get(),
+                                     /* image_processing_options= */ nullptr, 0,
+                                     &result, &error_msg),
+      kMpInvalidArgument);
+  EXPECT_THAT(error_msg, HasSubstr("monotonically increasing"));
+  MpErrorFree(error_msg);
+
+  ASSERT_EQ(MpFaceLandmarkerReset(landmarker, /* error_msg= */ nullptr), kMpOk);
+  ASSERT_EQ(
+      MpFaceLandmarkerDetectForVideo(landmarker, image.get(),
+                                     /* image_processing_options= */ nullptr, 0,
+                                     &result, /* error_msg= */ nullptr),
+      kMpOk);
+  MpFaceLandmarkerCloseResult(&result);
+  EXPECT_EQ(MpFaceLandmarkerClose(landmarker, /* error_msg= */ nullptr), kMpOk);
+}
+
 // A structure to support LiveStreamModeTest below. This structure holds a
 // static method `Fn` for a callback function of C API. A `static` qualifier
 // allows to take an address of the method to follow API style. Another static

--- a/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h
+++ b/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <optional>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "mediapipe/framework/formats/image.h"
 #include "mediapipe/tasks/cc/core/base_options.h"
@@ -185,6 +186,12 @@ class FaceLandmarker : tasks::vision::core::BaseVisionTaskApi {
   absl::Status DetectAsync(Image image, int64_t timestamp_ms,
                            std::optional<core::ImageProcessingOptions>
                                image_processing_options = std::nullopt);
+
+  // Resets the FaceLandmarker so it can process a new video or live stream
+  // starting at any timestamp. Restarts the underlying graph (clearing tracker
+  // state and the monotonic timestamp clock) without reloading the model.
+  // Only needed in VIDEO or LIVE_STREAM running mode.
+  absl::Status Reset() { return runner_->Restart(); }
 
   // Shuts down the FaceLandmarker when all works are done.
   absl::Status Close() { return runner_->Close(); }

--- a/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker_test.cc
+++ b/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker_test.cc
@@ -55,6 +55,7 @@ namespace {
 
 using ::file::Defaults;
 using ::mediapipe::tasks::vision::core::ImageProcessingOptions;
+using ::testing::HasSubstr;
 using ::testing::TestParamInfo;
 using ::testing::TestWithParam;
 using ::testing::Values;
@@ -414,6 +415,30 @@ INSTANTIATE_TEST_SUITE_P(
     [](const TestParamInfo<LiveStreamModeTest::ParamType>& info) {
       return info.param.test_name;
     });
+
+TEST(FaceLandmarkerResetTest, AllowsNewVideoAfterReset) {
+  MP_ASSERT_OK_AND_ASSIGN(
+      Image image, DecodeImageFromFile(file::JoinPath(
+                       "./", kTestDataDirectory, kPortraitImageName)));
+  auto options = std::make_unique<FaceLandmarkerOptions>();
+  options->base_options.model_asset_path = file::JoinPath(
+      "./", kTestDataDirectory, kFaceLandmarkerWithBlendshapesModelBundleName);
+  options->running_mode = core::RunningMode::VIDEO;
+
+  MP_ASSERT_OK_AND_ASSIGN(std::unique_ptr<FaceLandmarker> face_landmarker,
+                          FaceLandmarker::Create(std::move(options)));
+  MP_ASSERT_OK(face_landmarker->DetectForVideo(image, /*timestamp_ms=*/1));
+
+  absl::StatusOr<FaceLandmarkerResult> out_of_order =
+      face_landmarker->DetectForVideo(image, /*timestamp_ms=*/0);
+  EXPECT_FALSE(out_of_order.ok());
+  EXPECT_THAT(out_of_order.status().message(),
+              HasSubstr("monotonically increasing"));
+
+  MP_ASSERT_OK(face_landmarker->Reset());
+  MP_ASSERT_OK(face_landmarker->DetectForVideo(image, /*timestamp_ms=*/0));
+  MP_ASSERT_OK(face_landmarker->Close());
+}
 
 }  // namespace
 }  // namespace face_landmarker

--- a/mediapipe/tasks/python/test/vision/face_landmarker_test.py
+++ b/mediapipe/tasks/python/test/vision/face_landmarker_test.py
@@ -405,6 +405,22 @@ class FaceLandmarkerTest(parameterized.TestCase):
       ):
         landmarker.detect_for_video(self.test_image, 0)
 
+  def test_reset_allows_new_video_after_reset(self):
+    options = _FaceLandmarkerOptions(
+        base_options=_BaseOptions(model_asset_path=self.model_path),
+        running_mode=_RUNNING_MODE.VIDEO,
+    )
+    with _FaceLandmarker.create_from_options(options) as landmarker:
+      unused_result = landmarker.detect_for_video(self.test_image, 1)
+      with self.assertRaisesRegex(
+          ValueError, r'Input timestamp must be monotonically increasing'
+      ):
+        landmarker.detect_for_video(self.test_image, 0)
+
+      landmarker.reset()
+      reset_result = landmarker.detect_for_video(self.test_image, 0)
+      self.assertIsInstance(reset_result, FaceLandmarkerResult)
+
   @parameterized.parameters(
       (
           _FACE_LANDMARKER_BUNDLE_ASSET_FILE,

--- a/mediapipe/tasks/python/vision/face_landmarker.py
+++ b/mediapipe/tasks/python/vision/face_landmarker.py
@@ -3073,6 +3073,10 @@ _CTYPES_SIGNATURES = (
         'MpFaceLandmarkerClose',
         (ctypes.c_void_p,),
     ),
+    mediapipe_c_utils.CStatusFunction(
+        'MpFaceLandmarkerReset',
+        (ctypes.c_void_p,),
+    ),
 )
 
 
@@ -3324,6 +3328,19 @@ class FaceLandmarker:
         c_image_processing_options,
         timestamp_ms,
     )
+
+  def reset(self) -> None:
+    """Resets internal state so a new video can start at any timestamp.
+
+    Call this between videos in VIDEO or LIVE_STREAM mode. The model stays
+    loaded; only tracker state and the monotonic timestamp clock are cleared.
+
+    Raises:
+      RuntimeError: If the FaceLandmarker has already been closed.
+    """
+    if not self._handle:
+      raise RuntimeError('FaceLandmarker has been closed.')
+    self._lib.MpFaceLandmarkerReset(self._handle)  # pyrefly: ignore[missing-attribute]
 
   def close(self):
     """Closes the FaceLandmarker."""


### PR DESCRIPTION
## Summary

In VIDEO / LIVE_STREAM mode, FaceLandmarker requires monotonically increasing timestamps and keeps association/tracker state. Processing a second video today means constructing a new task (and reloading the model). Sending a black frame was a workaround.

`TaskRunner::Restart()` already closes and restarts the graph (resets `last_seen_` and calculator Open() state) without reloading the model. This PR exposes that as `reset()`.

Fixes #6010

## API

```python
landmarker = FaceLandmarker.create_from_options(options)  # VIDEO mode
result = landmarker.detect_for_video(frame, timestamp_ms)

# next file
landmarker.reset()
result = landmarker.detect_for_video(first_frame_of_next_video, 0)
```

Same method on C++ (`FaceLandmarker::Reset`) and C (`MpFaceLandmarkerReset`).

## Test plan

- [x] C++: after timestamp 1, timestamp 0 fails; `Reset()` then timestamp 0 succeeds
- [x] C API: same sequence
- [x] Python: `test_reset_allows_new_video_after_reset`
- [ ] `bazel test //mediapipe/tasks/cc/vision/face_landmarker:face_landmarker_test //mediapipe/tasks/c/vision/face_landmarker:face_landmarker_test //mediapipe/tasks/python/test/vision:face_landmarker_test`

@schmidt-sebastian @kuaashish @HarishPermal @tyrmullen @kalyan2789g @akashvverma1995 @ayushgdev @lu-wang-g