### PR TITLE
Allow live FaceLandmarker threshold updates

### DIFF
--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.cc
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.cc
@@ -204,6 +204,16 @@ absl::Status CppFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker) {
   return absl::OkStatus();
 }
 
+absl::Status CppFaceLandmarkerSetOptions(MpFaceLandmarkerPtr landmarker,
+                                         int num_faces,
+                                         float min_face_detection_confidence,
+                                         float min_face_presence_confidence,
+                                         float min_tracking_confidence) {
+  return GetCppLandmarker(landmarker)->SetOptions(
+      num_faces, min_face_detection_confidence, min_face_presence_confidence,
+      min_tracking_confidence);
+}
+
 }  // namespace mediapipe::tasks::c::vision::face_landmarker
 
 extern "C" {
@@ -257,6 +267,19 @@ MpStatus MpFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker,
   absl::Status status =
       mediapipe::tasks::c::vision::face_landmarker::CppFaceLandmarkerClose(
           landmarker);
+  return mediapipe::tasks::c::core::HandleStatus(status, error_msg);
+}
+
+MpStatus MpFaceLandmarkerSetOptions(MpFaceLandmarkerPtr landmarker,
+                                    int num_faces,
+                                    float min_face_detection_confidence,
+                                    float min_face_presence_confidence,
+                                    float min_tracking_confidence,
+                                    char** error_msg) {
+  absl::Status status =
+      mediapipe::tasks::c::vision::face_landmarker::CppFaceLandmarkerSetOptions(
+          landmarker, num_faces, min_face_detection_confidence,
+          min_face_presence_confidence, min_tracking_confidence);
   return mediapipe::tasks::c::core::HandleStatus(status, error_msg);
 }
 

--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.h
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker.h
@@ -173,6 +173,20 @@ MP_EXPORT void MpFaceLandmarkerCloseResult(MpFaceLandmarkerResult* result);
 MP_EXPORT MpStatus MpFaceLandmarkerClose(MpFaceLandmarkerPtr landmarker,
                                          char** error_msg);
 
+// Updates detector / tracker thresholds on a running FaceLandmarker without
+// constructing a new task. The model file stays in memory; the graph is
+// rebuilt so the next detect call uses the new values.
+// `num_faces` must be >= 1. Confidence values must be in [0, 1].
+//
+// Returns `kMpOk` on success. To obtain a detailed error, error_msg must be
+// non-null pointer to a char*, which will be populated with a newly-allocated
+// error message upon failure. It's the caller responsibility to free the error
+// message with MpErrorFree().
+MP_EXPORT MpStatus MpFaceLandmarkerSetOptions(
+    MpFaceLandmarkerPtr landmarker, int num_faces,
+    float min_face_detection_confidence, float min_face_presence_confidence,
+    float min_tracking_confidence, char** error_msg);
+
 #ifdef __cplusplus
 }  // extern C
 #endif

--- a/mediapipe/tasks/c/vision/face_landmarker/face_landmarker_test.cc
+++ b/mediapipe/tasks/c/vision/face_landmarker/face_landmarker_test.cc
@@ -348,4 +348,55 @@ TEST(FaceLandmarkerTest, InvalidArgumentHandling) {
   MpErrorFree(error_msg);
 }
 
+TEST(FaceLandmarkerTest, SetOptionsUpdatesThresholdsAndKeepsDetecting) {
+  const auto image = GetImage(GetFullPath(kImageFile));
+  const std::string model_path = GetFullPath(kModelName);
+  MpFaceLandmarkerOptions options = {
+      /* base_options= */ {/* model_asset_buffer= */ nullptr,
+                           /* model_asset_buffer_count= */ 0,
+                           /* model_asset_path= */ model_path.c_str()},
+      /* running_mode= */ MpRunningMode::MP_RUNNING_MODE_IMAGE,
+      /* num_faces= */ 1,
+      /* min_face_detection_confidence= */ 0.5,
+      /* min_face_presence_confidence= */ 0.5,
+      /* min_tracking_confidence= */ 0.5,
+      /* output_face_blendshapes = */ false,
+      /* output_facial_transformation_matrixes = */ false,
+  };
+
+  MpFaceLandmarkerPtr landmarker;
+  ASSERT_EQ(
+      MpFaceLandmarkerCreate(&options, &landmarker, /* error_msg= */ nullptr),
+      kMpOk);
+
+  MpFaceLandmarkerResult result;
+  ASSERT_EQ(MpFaceLandmarkerDetectImage(landmarker, image.get(),
+                                        /* image_processing_options= */ nullptr,
+                                        &result, /* error_msg= */ nullptr),
+            kMpOk);
+  EXPECT_GE(result.face_landmarks_count, 1);
+  MpFaceLandmarkerCloseResult(&result);
+
+  ASSERT_EQ(MpFaceLandmarkerSetOptions(landmarker, /* num_faces= */ 1,
+                                       /* min_face_detection_confidence= */ 0.1,
+                                       /* min_face_presence_confidence= */ 0.1,
+                                       /* min_tracking_confidence= */ 0.1,
+                                       /* error_msg= */ nullptr),
+            kMpOk);
+  ASSERT_EQ(MpFaceLandmarkerDetectImage(landmarker, image.get(),
+                                        /* image_processing_options= */ nullptr,
+                                        &result, /* error_msg= */ nullptr),
+            kMpOk);
+  EXPECT_GE(result.face_landmarks_count, 1);
+  MpFaceLandmarkerCloseResult(&result);
+
+  char* error_msg = nullptr;
+  EXPECT_EQ(MpFaceLandmarkerSetOptions(landmarker, /* num_faces= */ 0, 0.5, 0.5,
+                                       0.5, &error_msg),
+            kMpInvalidArgument);
+  EXPECT_THAT(error_msg, HasSubstr("num_faces"));
+  MpErrorFree(error_msg);
+  EXPECT_EQ(MpFaceLandmarkerClose(landmarker, /* error_msg= */ nullptr), kMpOk);
+}
+
 }  // namespace

--- a/mediapipe/tasks/cc/vision/face_landmarker/BUILD
+++ b/mediapipe/tasks/cc/vision/face_landmarker/BUILD
@@ -141,6 +141,7 @@ cc_library(
     deps = [
         ":face_landmarker_graph",
         ":face_landmarker_result",
+        "//mediapipe/framework:calculator_framework",
         "//mediapipe/framework/api2:builder",
         "//mediapipe/framework/formats:classification_cc_proto",
         "//mediapipe/framework/formats:image",
@@ -148,9 +149,12 @@ cc_library(
         "//mediapipe/framework/formats:matrix",
         "//mediapipe/framework/formats:matrix_data_cc_proto",
         "//mediapipe/framework/formats:rect_cc_proto",
+        "//mediapipe/framework/port:status",
         "//mediapipe/tasks/cc/components/containers:classification_result",
         "//mediapipe/tasks/cc/core:base_options",
         "//mediapipe/tasks/cc/core:base_task_api",
+        "//mediapipe/tasks/cc/core:host_environment",
+        "//mediapipe/tasks/cc/core:mediapipe_builtin_op_resolver",
         "//mediapipe/tasks/cc/core:task_runner",
         "//mediapipe/tasks/cc/core:utils",
         "//mediapipe/tasks/cc/vision/core:base_vision_task_api",
@@ -161,7 +165,9 @@ cc_library(
         "//mediapipe/tasks/cc/vision/face_geometry/proto:face_geometry_cc_proto",
         "//mediapipe/tasks/cc/vision/face_landmarker/proto:face_landmarker_graph_options_cc_proto",
         "//mediapipe/tasks/cc/vision/face_landmarker/proto:face_landmarks_detector_graph_options_cc_proto",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.cc
+++ b/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.cc
@@ -15,17 +15,26 @@ limitations under the License.
 
 #include "mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h"
 
+#include <memory>
+#include <string>
 #include <utility>
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "mediapipe/framework/api2/builder.h"
+#include "mediapipe/framework/calculator_framework.h"
 #include "mediapipe/framework/formats/classification.pb.h"
 #include "mediapipe/framework/formats/image.h"
 #include "mediapipe/framework/formats/landmark.pb.h"
 #include "mediapipe/framework/formats/matrix.h"
 #include "mediapipe/framework/formats/matrix_data.pb.h"
 #include "mediapipe/framework/formats/rect.pb.h"
+#include "mediapipe/framework/port/status_macros.h"
 #include "mediapipe/tasks/cc/components/containers/classification_result.h"
 #include "mediapipe/tasks/cc/core/base_task_api.h"
+#include "mediapipe/tasks/cc/core/host_environment.h"
+#include "mediapipe/tasks/cc/core/mediapipe_builtin_op_resolver.h"
 #include "mediapipe/tasks/cc/core/task_runner.h"
 #include "mediapipe/tasks/cc/core/utils.h"
 #include "mediapipe/tasks/cc/vision/core/base_vision_task_api.h"
@@ -152,53 +161,91 @@ FaceLandmarkerResult GetFaceLandmarkerResultFromPacketMap(
       /* facial_transformation_matrixes_proto= */ matrix_data_list);
 }
 
+bool ConfidenceInRange(float value) { return value >= 0.0f && value <= 1.0f; }
+
 }  // namespace
+
+struct FaceLandmarker::RebuildState {
+  proto::FaceLandmarkerGraphOptions graph_options;
+  bool output_face_blendshapes = false;
+  bool output_facial_transformation_matrixes = false;
+  core::RunningMode running_mode = core::RunningMode::IMAGE;
+  tasks::core::PacketsCallback packets_callback;
+  bool disable_default_service = false;
+  tasks::core::HostEnvironment host_environment =
+      tasks::core::HOST_ENVIRONMENT_UNKNOWN;
+  tasks::core::HostSystem host_system = tasks::core::HOST_SYSTEM_UNKNOWN;
+  std::string host_version;
+  std::string ca_bundle_path;
+};
+
+FaceLandmarker::~FaceLandmarker() = default;
 
 absl::StatusOr<std::unique_ptr<FaceLandmarker>> FaceLandmarker::Create(
     std::unique_ptr<FaceLandmarkerOptions> options) {
   auto options_proto = ConvertFaceLandmarkerGraphOptionsProto(options.get());
-  tasks::core::PacketsCallback packets_callback = nullptr;
+  auto rebuild_state = std::make_unique<RebuildState>();
+  rebuild_state->graph_options = *options_proto;
+  rebuild_state->output_face_blendshapes = options->output_face_blendshapes;
+  rebuild_state->output_facial_transformation_matrixes =
+      options->output_facial_transformation_matrixes;
+  rebuild_state->running_mode = options->running_mode;
+  rebuild_state->disable_default_service =
+      options->base_options.disable_default_service;
+  rebuild_state->host_environment = options->base_options.host_environment;
+  rebuild_state->host_system = options->base_options.host_system;
+  rebuild_state->host_version = options->base_options.host_version;
+  rebuild_state->ca_bundle_path = options->base_options.ca_bundle_path;
+
   if (options->result_callback) {
     auto result_callback = options->result_callback;
-    packets_callback = [=](absl::StatusOr<tasks::core::PacketMap> packet_map) {
-      if (!packet_map.ok()) {
-        Image image;
-        result_callback(packet_map.status(), image, Timestamp::Unset().Value());
-        return;
-      }
-      if (packet_map->at(kImageOutStreamName).IsEmpty()) {
-        return;
-      }
-      Packet image_packet = packet_map->at(kImageOutStreamName);
-      if (packet_map->at(kNormLandmarksStreamName).IsEmpty()) {
-        Packet empty_packet = packet_map->at(kNormLandmarksStreamName);
-        result_callback(
-            {FaceLandmarkerResult()}, image_packet.Get<Image>(),
-            empty_packet.Timestamp().Value() / kMicroSecondsPerMilliSecond);
-        return;
-      }
-      result_callback(
-          GetFaceLandmarkerResultFromPacketMap(*packet_map),
-          image_packet.Get<Image>(),
-          packet_map->at(kNormLandmarksStreamName).Timestamp().Value() /
-              kMicroSecondsPerMilliSecond);
-    };
+    rebuild_state->packets_callback =
+        [=](absl::StatusOr<tasks::core::PacketMap> packet_map) {
+          if (!packet_map.ok()) {
+            Image image;
+            result_callback(packet_map.status(), image,
+                            Timestamp::Unset().Value());
+            return;
+          }
+          if (packet_map->at(kImageOutStreamName).IsEmpty()) {
+            return;
+          }
+          Packet image_packet = packet_map->at(kImageOutStreamName);
+          if (packet_map->at(kNormLandmarksStreamName).IsEmpty()) {
+            Packet empty_packet = packet_map->at(kNormLandmarksStreamName);
+            result_callback(
+                {FaceLandmarkerResult()}, image_packet.Get<Image>(),
+                empty_packet.Timestamp().Value() / kMicroSecondsPerMilliSecond);
+            return;
+          }
+          result_callback(
+              GetFaceLandmarkerResultFromPacketMap(*packet_map),
+              image_packet.Get<Image>(),
+              packet_map->at(kNormLandmarksStreamName).Timestamp().Value() /
+                  kMicroSecondsPerMilliSecond);
+        };
   }
-  return core::VisionTaskApiFactory::Create<FaceLandmarker,
-                                            FaceLandmarkerGraphOptionsProto>(
-      {.config = CreateGraphConfig(
-           std::move(options_proto), options->output_face_blendshapes,
-           options->output_facial_transformation_matrixes,
-           options->running_mode == core::RunningMode::LIVE_STREAM),
-       .task_name = kTaskName,
-       .task_running_mode = core::GetCoreRunningMode(options->running_mode),
-       .op_resolver = std::move(options->base_options.op_resolver),
-       .packets_callback = std::move(packets_callback),
-       .disable_default_service = options->base_options.disable_default_service,
-       .host_environment = options->base_options.host_environment,
-       .host_system = options->base_options.host_system,
-       .host_version = options->base_options.host_version,
-       .ca_bundle_path = options->base_options.ca_bundle_path});
+
+  ABSL_ASSIGN_OR_RETURN(
+      auto landmarker,
+      core::VisionTaskApiFactory::Create<FaceLandmarker,
+                                         FaceLandmarkerGraphOptionsProto>(
+          {.config = CreateGraphConfig(
+               std::move(options_proto), options->output_face_blendshapes,
+               options->output_facial_transformation_matrixes,
+               options->running_mode == core::RunningMode::LIVE_STREAM),
+           .task_name = kTaskName,
+           .task_running_mode = core::GetCoreRunningMode(options->running_mode),
+           .op_resolver = std::move(options->base_options.op_resolver),
+           .packets_callback = rebuild_state->packets_callback,
+           .disable_default_service =
+               options->base_options.disable_default_service,
+           .host_environment = options->base_options.host_environment,
+           .host_system = options->base_options.host_system,
+           .host_version = options->base_options.host_version,
+           .ca_bundle_path = options->base_options.ca_bundle_path}));
+  landmarker->rebuild_state_ = std::move(rebuild_state);
+  return landmarker;
 }
 
 absl::StatusOr<FaceLandmarkerResult> FaceLandmarker::Detect(
@@ -253,6 +300,60 @@ absl::Status FaceLandmarker::DetectAsync(
        {kNormRectStreamName,
         MakePacket<NormalizedRect>(std::move(norm_rect))
             .At(Timestamp(timestamp_ms * kMicroSecondsPerMilliSecond))}});
+}
+
+absl::Status FaceLandmarker::SetOptions(int num_faces,
+                                        float min_face_detection_confidence,
+                                        float min_face_presence_confidence,
+                                        float min_tracking_confidence) {
+  if (!rebuild_state_) {
+    return absl::FailedPreconditionError("FaceLandmarker is not initialized.");
+  }
+  if (num_faces < 1) {
+    return absl::InvalidArgumentError("num_faces must be >= 1.");
+  }
+  if (!ConfidenceInRange(min_face_detection_confidence) ||
+      !ConfidenceInRange(min_face_presence_confidence) ||
+      !ConfidenceInRange(min_tracking_confidence)) {
+    return absl::InvalidArgumentError(
+        "Confidence thresholds must be in the range [0.0, 1.0].");
+  }
+
+  rebuild_state_->graph_options.mutable_face_detector_graph_options()
+      ->set_num_faces(num_faces);
+  rebuild_state_->graph_options.mutable_face_detector_graph_options()
+      ->set_min_detection_confidence(min_face_detection_confidence);
+  rebuild_state_->graph_options
+      .mutable_face_landmarks_detector_graph_options()
+      ->set_min_detection_confidence(min_face_presence_confidence);
+  rebuild_state_->graph_options.set_min_tracking_confidence(
+      min_tracking_confidence);
+
+  auto options_copy = std::make_unique<FaceLandmarkerGraphOptionsProto>(
+      rebuild_state_->graph_options);
+  ABSL_ASSIGN_OR_RETURN(
+      auto replacement,
+      core::VisionTaskApiFactory::Create<FaceLandmarker,
+                                         FaceLandmarkerGraphOptionsProto>(
+          {.config = CreateGraphConfig(
+               std::move(options_copy),
+               rebuild_state_->output_face_blendshapes,
+               rebuild_state_->output_facial_transformation_matrixes,
+               rebuild_state_->running_mode == core::RunningMode::LIVE_STREAM),
+           .task_name = kTaskName,
+           .task_running_mode =
+               core::GetCoreRunningMode(rebuild_state_->running_mode),
+           .op_resolver =
+               std::make_unique<tasks::core::MediaPipeBuiltinOpResolver>(),
+           .packets_callback = rebuild_state_->packets_callback,
+           .disable_default_service = rebuild_state_->disable_default_service,
+           .host_environment = rebuild_state_->host_environment,
+           .host_system = rebuild_state_->host_system,
+           .host_version = rebuild_state_->host_version,
+           .ca_bundle_path = rebuild_state_->ca_bundle_path}));
+  ABSL_RETURN_IF_ERROR(runner_->Close());
+  runner_ = std::move(replacement->runner_);
+  return absl::OkStatus();
 }
 
 }  // namespace face_landmarker

--- a/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h
+++ b/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <optional>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "mediapipe/framework/formats/image.h"
 #include "mediapipe/tasks/cc/core/base_options.h"
@@ -103,6 +104,7 @@ struct FaceLandmarkerOptions {
 class FaceLandmarker : tasks::vision::core::BaseVisionTaskApi {
  public:
   using BaseVisionTaskApi::BaseVisionTaskApi;
+  ~FaceLandmarker() override;
 
   // Creates a FaceLandmarker from a FaceLandmarkerOptions to process image data
   // or streaming data. Face landmarker can be created with one of the following
@@ -186,8 +188,23 @@ class FaceLandmarker : tasks::vision::core::BaseVisionTaskApi {
                            std::optional<core::ImageProcessingOptions>
                                image_processing_options = std::nullopt);
 
+  // Updates detector / tracker thresholds on a running FaceLandmarker without
+  // the caller constructing a new task. The model file stays in memory; the
+  // graph is rebuilt with the new values so the next Detect / DetectForVideo /
+  // DetectAsync call uses them.
+  //
+  // `num_faces` must be >= 1. Confidence values must be in [0, 1].
+  absl::Status SetOptions(int num_faces,
+                          float min_face_detection_confidence,
+                          float min_face_presence_confidence,
+                          float min_tracking_confidence);
+
   // Shuts down the FaceLandmarker when all works are done.
   absl::Status Close() { return runner_->Close(); }
+
+ private:
+  struct RebuildState;
+  std::unique_ptr<RebuildState> rebuild_state_;
 };
 
 }  // namespace face_landmarker

--- a/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker_test.cc
+++ b/mediapipe/tasks/cc/vision/face_landmarker/face_landmarker_test.cc
@@ -55,6 +55,7 @@ namespace {
 
 using ::file::Defaults;
 using ::mediapipe::tasks::vision::core::ImageProcessingOptions;
+using ::testing::HasSubstr;
 using ::testing::TestParamInfo;
 using ::testing::TestWithParam;
 using ::testing::Values;
@@ -414,6 +415,35 @@ INSTANTIATE_TEST_SUITE_P(
     [](const TestParamInfo<LiveStreamModeTest::ParamType>& info) {
       return info.param.test_name;
     });
+
+TEST(FaceLandmarkerSetOptionsTest, UpdatesThresholdsAndKeepsDetecting) {
+  MP_ASSERT_OK_AND_ASSIGN(
+      Image image, DecodeImageFromFile(file::JoinPath(
+                       "./", kTestDataDirectory, kPortraitImageName)));
+  auto options = std::make_unique<FaceLandmarkerOptions>();
+  options->base_options.model_asset_path = file::JoinPath(
+      "./", kTestDataDirectory, kFaceLandmarkerWithBlendshapesModelBundleName);
+  options->running_mode = core::RunningMode::IMAGE;
+
+  MP_ASSERT_OK_AND_ASSIGN(std::unique_ptr<FaceLandmarker> face_landmarker,
+                          FaceLandmarker::Create(std::move(options)));
+  MP_ASSERT_OK_AND_ASSIGN(FaceLandmarkerResult before,
+                          face_landmarker->Detect(image));
+  ASSERT_FALSE(before.face_landmarks.empty());
+
+  MP_ASSERT_OK(face_landmarker->SetOptions(
+      /*num_faces=*/1, /*min_face_detection_confidence=*/0.1,
+      /*min_face_presence_confidence=*/0.1, /*min_tracking_confidence=*/0.1));
+  MP_ASSERT_OK_AND_ASSIGN(FaceLandmarkerResult after,
+                          face_landmarker->Detect(image));
+  ASSERT_FALSE(after.face_landmarks.empty());
+
+  EXPECT_THAT(face_landmarker->SetOptions(0, 0.5, 0.5, 0.5).message(),
+              HasSubstr("num_faces"));
+  EXPECT_THAT(face_landmarker->SetOptions(1, 1.5, 0.5, 0.5).message(),
+              HasSubstr("Confidence thresholds"));
+  MP_ASSERT_OK(face_landmarker->Close());
+}
 
 }  // namespace
 }  // namespace face_landmarker

--- a/mediapipe/tasks/python/test/vision/face_landmarker_test.py
+++ b/mediapipe/tasks/python/test/vision/face_landmarker_test.py
@@ -247,6 +247,27 @@ class FaceLandmarkerTest(parameterized.TestCase):
     # in a context.
     landmarker.close()
 
+  def test_set_options_updates_thresholds_and_keeps_detecting(self):
+    options = _FaceLandmarkerOptions(
+        base_options=_BaseOptions(model_asset_path=self.model_path),
+        running_mode=_RUNNING_MODE.IMAGE,
+    )
+    with _FaceLandmarker.create_from_options(options) as landmarker:
+      before = landmarker.detect(self.test_image)
+      self.assertGreater(len(before.face_landmarks), 0)
+
+      landmarker.set_options(
+          num_faces=1,
+          min_face_detection_confidence=0.1,
+          min_face_presence_confidence=0.1,
+          min_tracking_confidence=0.1,
+      )
+      after = landmarker.detect(self.test_image)
+      self.assertGreater(len(after.face_landmarks), 0)
+
+      with self.assertRaisesRegex(ValueError, r'num_faces'):
+        landmarker.set_options(num_faces=0)
+
   @parameterized.parameters(
       (
           ModelFileType.FILE_NAME,

--- a/mediapipe/tasks/python/vision/face_landmarker.py
+++ b/mediapipe/tasks/python/vision/face_landmarker.py
@@ -3073,6 +3073,16 @@ _CTYPES_SIGNATURES = (
         'MpFaceLandmarkerClose',
         (ctypes.c_void_p,),
     ),
+    mediapipe_c_utils.CStatusFunction(
+        'MpFaceLandmarkerSetOptions',
+        (
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_float,
+            ctypes.c_float,
+            ctypes.c_float,
+        ),
+    ),
 )
 
 
@@ -3083,6 +3093,7 @@ class FaceLandmarker:
   _handle: ctypes.c_void_p
   _dispatcher: _AsyncResultDispatcher
   _async_callback: _C_TYPES_RESULT_CALLBACK
+  _options: FaceLandmarkerOptions
 
   def __init__(
       self,
@@ -3090,6 +3101,7 @@ class FaceLandmarker:
       handle: ctypes.c_void_p,
       dispatcher: _AsyncResultDispatcher,
       async_callback: _C_TYPES_RESULT_CALLBACK,
+      options: FaceLandmarkerOptions,
   ):
     """Initializes the face landmarker.
 
@@ -3098,11 +3110,13 @@ class FaceLandmarker:
       handle: The C pointer to the face landmarker.
       dispatcher: The async result handler for the face landmarker.
       async_callback: The c callback for the face landmarker.
+      options: The options used to create this landmarker.
     """
     self._lib = lib
     self._handle = handle
     self._dispatcher = dispatcher
     self._async_callback = async_callback
+    self._options = options
 
   @classmethod
   def create_from_model_path(cls, model_path: str) -> 'FaceLandmarker':
@@ -3183,7 +3197,11 @@ class FaceLandmarker:
         ctypes.byref(options_c), ctypes.byref(landmarker)
     )
     return FaceLandmarker(
-        lib, landmarker, dispatcher=dispatcher, async_callback=c_callback
+        lib,
+        landmarker,
+        dispatcher=dispatcher,
+        async_callback=c_callback,
+        options=options,
     )
 
   def detect(
@@ -3323,6 +3341,50 @@ class FaceLandmarker:
         c_image,
         c_image_processing_options,
         timestamp_ms,
+    )
+
+  def set_options(
+      self,
+      *,
+      num_faces: Optional[int] = None,
+      min_face_detection_confidence: Optional[float] = None,
+      min_face_presence_confidence: Optional[float] = None,
+      min_tracking_confidence: Optional[float] = None,
+  ) -> None:
+    """Updates live detector / tracker thresholds without recreating the task.
+
+    Only the provided keyword arguments are changed. The model stays loaded;
+    the graph is rebuilt so the next detect call uses the new values. Useful
+    for a settings UI on a live camera pipeline.
+
+    Args:
+      num_faces: Maximum number of faces to detect. Must be >= 1.
+      min_face_detection_confidence: Minimum face detection score in [0, 1].
+      min_face_presence_confidence: Minimum face presence score in [0, 1].
+      min_tracking_confidence: Minimum tracking score in [0, 1].
+
+    Raises:
+      RuntimeError: If the FaceLandmarker has already been closed.
+      ValueError: If a provided value is out of range.
+    """
+    if not self._handle:
+      raise RuntimeError('FaceLandmarker has been closed.')
+    if num_faces is not None:
+      self._options.num_faces = num_faces
+    if min_face_detection_confidence is not None:
+      self._options.min_face_detection_confidence = (
+          min_face_detection_confidence
+      )
+    if min_face_presence_confidence is not None:
+      self._options.min_face_presence_confidence = min_face_presence_confidence
+    if min_tracking_confidence is not None:
+      self._options.min_tracking_confidence = min_tracking_confidence
+    self._lib.MpFaceLandmarkerSetOptions(  # pyrefly: ignore[missing-attribute]
+        self._handle,
+        self._options.num_faces,
+        self._options.min_face_detection_confidence,
+        self._options.min_face_presence_confidence,
+        self._options.min_tracking_confidence,
     )
 
   def close(self):


### PR DESCRIPTION
## Summary

Python FaceLandmarker could not change `num_faces`, `min_face_detection_confidence`, `min_face_presence_confidence`, or `min_tracking_confidence` after create. A settings UI on a live camera had to destroy the task and reload the model.

`set_options()` keeps the same landmarker object and the model bytes already in memory, rebuilds the graph with the new values, and the next `detect` / `detect_for_video` / `detect_async` uses them. Same API on C++ (`SetOptions`) and C (`MpFaceLandmarkerSetOptions`). Web already had `setOptions()`.

Fixes #5847

## API

```python
landmarker.set_options(
    num_faces=2,
    min_face_detection_confidence=0.3,
    min_face_presence_confidence=0.3,
    min_tracking_confidence=0.3,
)
```

Only the provided kwargs are updated. `num_faces` must be >= 1; confidences must be in `[0, 1]`.

## Test plan

- [x] C++: detect, SetOptions, detect again; invalid num_faces / confidence rejected
- [x] C API: same sequence
- [x] Python: `test_set_options_updates_thresholds_and_keeps_detecting`
- [ ] `bazel test //mediapipe/tasks/cc/vision/face_landmarker:face_landmarker_test //mediapipe/tasks/c/vision/face_landmarker:face_landmarker_test //mediapipe/tasks/python/test/vision:face_landmarker_test`

@schmidt-sebastian @kuaashish @HarishPermal @tyrmullen @kalyan2789g @akashvverma1995 @ayushgdev @lu-wang-g