### PR TITLE
Add getLabels() and getDisplayNames() on Web classifiers

### DIFF
--- a/mediapipe/tasks/web/audio/audio_classifier/BUILD
+++ b/mediapipe/tasks/web/audio/audio_classifier/BUILD
@@ -16,6 +16,7 @@ ts_library(
     visibility = ["//visibility:public"],
     deps = [
         ":audio_classifier_types",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
         "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/tasks/cc/audio/audio_classifier/proto:audio_classifier_graph_options_jspb_proto",
@@ -26,6 +27,7 @@ ts_library(
         "//mediapipe/tasks/web/components/containers:classification_result",
         "//mediapipe/tasks/web/components/processors:classifier_options",
         "//mediapipe/tasks/web/components/processors:classifier_result",
+        "//mediapipe/tasks/web/components/processors:label_map",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:classifier_options",
         "//mediapipe/tasks/web/core:task_runner",
@@ -56,10 +58,14 @@ ts_library(
     ],
     deps = [
         ":audio_classifier",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/framework/formats:classification_jspb_proto",
         "//mediapipe/tasks/cc/components/containers/proto:classifications_jspb_proto",
         "//mediapipe/tasks/web/core:task_runner_test_utils",
+        "//mediapipe/util:label_map_jspb_proto",
+        "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
 

--- a/mediapipe/tasks/web/audio/audio_classifier/audio_classifier.ts
+++ b/mediapipe/tasks/web/audio/audio_classifier/audio_classifier.ts
@@ -202,12 +202,14 @@ export class AudioClassifier extends AudioTaskRunner<AudioClassifierResult[]> {
   }
 
   /**
-   * Get the locale display-name list for the current model. Index-aligned
-   * with {@link getLabels}. Entries are empty strings when the model has no
-   * display name for that class.
+   * Get the locale display-name list for the current model.
+   *
+   * When the model includes a display-name associated file, the returned list
+   * is the same length as {@link getLabels} and index-aligned with it. When
+   * the model has no display names, an empty array is returned.
    *
    * @export
-   * @return The display names used by the current model.
+   * @return The display names used by the current model, or `[]` if none.
    */
   getDisplayNames(): string[] {
     return this.displayNames;

--- a/mediapipe/tasks/web/audio/audio_classifier/audio_classifier.ts
+++ b/mediapipe/tasks/web/audio/audio_classifier/audio_classifier.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
 import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {AudioClassifierGraphOptions} from '../../../../tasks/cc/audio/audio_classifier/proto/audio_classifier_graph_options_pb';
@@ -22,6 +23,10 @@ import {BaseOptions as BaseOptionsProto} from '../../../../tasks/cc/core/proto/b
 import {AudioTaskRunner} from '../../../../tasks/web/audio/core/audio_task_runner';
 import {convertClassifierOptionsToProto} from '../../../../tasks/web/components/processors/classifier_options';
 import {convertFromClassificationResultProto} from '../../../../tasks/web/components/processors/classifier_result';
+import {
+  categoryLabelMapFromItems,
+  findUniqueCalculatorNode,
+} from '../../../../tasks/web/components/processors/label_map';
 import {CachedGraphRunner} from '../../../../tasks/web/core/task_runner';
 import {WasmFileset} from '../../../../tasks/web/core/wasm_fileset';
 import {WasmModule} from '../../../../web/graph_runner/graph_runner';
@@ -39,6 +44,8 @@ const MEDIAPIPE_GRAPH =
 const AUDIO_STREAM = 'audio_in';
 const SAMPLE_RATE_STREAM = 'sample_rate';
 const TIMESTAMPED_CLASSIFICATIONS_STREAM = 'timestamped_classifications';
+const TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME =
+  'TensorsToClassificationCalculator';
 
 // The OSS JS API does not support the builder pattern.
 // tslint:disable:jspb-use-builder-pattern
@@ -46,6 +53,8 @@ const TIMESTAMPED_CLASSIFICATIONS_STREAM = 'timestamped_classifications';
 /** Performs audio classification. */
 export class AudioClassifier extends AudioTaskRunner<AudioClassifierResult[]> {
   private classificationResults: AudioClassifierResult[] = [];
+  private labels: string[] = [];
+  private displayNames: string[] = [];
   private readonly options = new AudioClassifierGraphOptions();
 
   /**
@@ -146,6 +155,62 @@ export class AudioClassifier extends AudioTaskRunner<AudioClassifierResult[]> {
       ),
     );
     return this.applyOptions(options);
+  }
+
+  protected override onGraphRefreshed(): void {
+    this.populateLabels();
+  }
+
+  /**
+   * Populate labels from TensorsToClassificationCalculator in the expanded
+   * graph. The calculator is configured from TFLite Model Metadata when the
+   * AudioClassifier graph is built.
+   */
+  private populateLabels(): void {
+    this.labels = [];
+    this.displayNames = [];
+    const node = findUniqueCalculatorNode(
+      this.getCalculatorGraphConfig(),
+      TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME,
+    );
+    if (!node) {
+      return;
+    }
+    const labelItems =
+      node
+        .getOptions()
+        ?.getExtension(TensorsToClassificationCalculatorOptions.ext)
+        ?.getLabelItemsMap() ?? new Map();
+    const labelMap = categoryLabelMapFromItems(labelItems);
+    this.labels = labelMap.labels;
+    this.displayNames = labelMap.displayNames;
+  }
+
+  /**
+   * Get the category label list the AudioClassifier can recognize. The index
+   * in the returned array corresponds to the category index in the model
+   * label map.
+   *
+   * If there is no labelmap provided in the model file, an empty array is
+   * returned.
+   *
+   * @export
+   * @return The labels used by the current model.
+   */
+  getLabels(): string[] {
+    return this.labels;
+  }
+
+  /**
+   * Get the locale display-name list for the current model. Index-aligned
+   * with {@link getLabels}. Entries are empty strings when the model has no
+   * display name for that class.
+   *
+   * @export
+   * @return The display names used by the current model.
+   */
+  getDisplayNames(): string[] {
+    return this.displayNames;
   }
 
   // TODO: Add a classifyStream() that takes a timestamp

--- a/mediapipe/tasks/web/audio/audio_classifier/audio_classifier_test.ts
+++ b/mediapipe/tasks/web/audio/audio_classifier/audio_classifier_test.ts
@@ -16,10 +16,17 @@
 
 import 'jasmine';
 
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {Classification, ClassificationList} from '../../../../framework/formats/classification_pb';
 import {ClassificationResult, Classifications} from '../../../../tasks/cc/components/containers/proto/classifications_pb';
-import {addJasmineCustomFloatEqualityTester, createSpyWasmModule, MediapipeTasksFake, verifyGraph, verifyListenersRegistered} from '../../../../tasks/web/core/task_runner_test_utils';
+import {addJasmineCustomFloatEqualityTester, createSpyWasmModule, MediapipeTasksFake, SpyWasmModule, verifyGraph, verifyListenersRegistered} from '../../../../tasks/web/core/task_runner_test_utils';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+import {
+  CALCULATOR_GRAPH_CONFIG_LISTENER_NAME,
+  SimpleListener,
+} from '../../../../web/graph_runner/graph_runner';
 
 import {AudioClassifier} from './audio_classifier';
 
@@ -33,6 +40,7 @@ class AudioClassifierFake extends AudioClassifier implements
       'mediapipe.tasks.audio.audio_classifier.AudioClassifierGraph';
   attachListenerSpies: jasmine.Spy[] = [];
   graph: CalculatorGraphConfig|undefined;
+  fakeWasmModule: SpyWasmModule;
 
   private protoVectorListener:
       ((binaryProtos: Uint8Array[], timestamp: number) => void)|undefined;
@@ -40,6 +48,8 @@ class AudioClassifierFake extends AudioClassifier implements
 
   constructor() {
     super(createSpyWasmModule(), /* glCanvas= */ null);
+    this.fakeWasmModule =
+        this.graphRunner.wasmModule as unknown as SpyWasmModule;
 
     this.attachListenerSpies[0] =
         spyOn(this.graphRunner, 'attachProtoVectorListener')
@@ -212,5 +222,58 @@ describe('AudioClassifier', () => {
     // Verify that gestures2 is not a concatenation of all previously returned
     // gestures.
     expect(classifications1).toEqual(classifications2);
+  });
+
+  describe('getLabels() and getDisplayNames()', () => {
+    function graphConfigWithLabels(
+        entries: Array<{name: string; displayName?: string}>): Uint8Array {
+      const graph = new CalculatorGraphConfig();
+      const node = new CalculatorGraphConfig.Node();
+      node.setName('TensorsToClassificationCalculator');
+      node.setCalculator('TensorsToClassificationCalculator');
+
+      const labelOptions = new TensorsToClassificationCalculatorOptions();
+      entries.forEach((entry, index) => {
+        const item = new LabelMapItem();
+        item.setName(entry.name);
+        if (entry.displayName !== undefined) {
+          item.setDisplayName(entry.displayName);
+        }
+        labelOptions.getLabelItemsMap().set(index, item);
+      });
+
+      const calculatorOptions = new CalculatorOptions();
+      calculatorOptions.setExtension(
+          TensorsToClassificationCalculatorOptions.ext, labelOptions);
+      node.setOptions(calculatorOptions);
+      graph.addNode(node);
+      return graph.serializeBinary();
+    }
+
+    async function loadLabelMap(
+        entries: Array<{name: string; displayName?: string}>): Promise<void> {
+      audioClassifier.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (audioClassifier.fakeWasmModule.simpleListeners![
+           CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+         ] as SimpleListener<Uint8Array>)(graphConfigWithLabels(entries), 0);
+      });
+      await audioClassifier.setOptions(
+          {baseOptions: {modelAssetBuffer: new Uint8Array([1])}});
+    }
+
+    it('returns empty lists when the model has no labelmap', () => {
+      expect(audioClassifier.getLabels()).toEqual([]);
+      expect(audioClassifier.getDisplayNames()).toEqual([]);
+    });
+
+    it('returns labels and display names from the model metadata', async () => {
+      await loadLabelMap([
+        {name: 'Speech', displayName: 'Habla'},
+        {name: 'Music', displayName: 'Música'},
+      ]);
+
+      expect(audioClassifier.getLabels()).toEqual(['Speech', 'Music']);
+      expect(audioClassifier.getDisplayNames()).toEqual(['Habla', 'Música']);
+    });
   });
 });

--- a/mediapipe/tasks/web/components/processors/BUILD
+++ b/mediapipe/tasks/web/components/processors/BUILD
@@ -151,3 +151,28 @@ jasmine_node_test(
     name = "landmark_result_test",
     srcs = [":landmark_result_test_lib"],
 )
+
+ts_library(
+    name = "label_map",
+    srcs = ["label_map.ts"],
+    deps = [
+        "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/util:label_map_jspb_proto",
+    ],
+)
+
+ts_library(
+    name = "label_map_test_lib",
+    testonly = True,
+    srcs = ["label_map_test.ts"],
+    deps = [
+        ":label_map",
+        "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/util:label_map_jspb_proto",
+    ],
+)
+
+jasmine_node_test(
+    name = "label_map_test",
+    srcs = [":label_map_test_lib"],
+)

--- a/mediapipe/tasks/web/components/processors/label_map.ts
+++ b/mediapipe/tasks/web/components/processors/label_map.ts
@@ -26,8 +26,9 @@ export interface CategoryLabelMap {
 /**
  * Converts a TFLite / MediaPipe label_items map into parallel arrays.
  *
- * Index `i` is `categoryName` / `displayName` for class id `i`. Missing
- * display names become an empty string so callers can zip the arrays.
+ * Index `i` is `categoryName` / `displayName` for class id `i`. TFLite
+ * metadata either ships a full display-name file (same length as labels) or
+ * none at all; if no item has a display name, `displayNames` is `[]`.
  */
 export function categoryLabelMapFromItems(
   labelItems: {
@@ -38,12 +39,17 @@ export function categoryLabelMapFromItems(
 ): CategoryLabelMap {
   const labels: string[] = [];
   const displayNames: string[] = [];
+  let hasDisplayName = false;
   labelItems.forEach((value, index) => {
     const i = Number(index);
     labels[i] = value.getName() ?? '';
-    displayNames[i] = value.getDisplayName() ?? '';
+    const displayName = value.getDisplayName() ?? '';
+    displayNames[i] = displayName;
+    if (displayName) {
+      hasDisplayName = true;
+    }
   });
-  return {labels, displayNames};
+  return {labels, displayNames: hasDisplayName ? displayNames : []};
 }
 
 /**

--- a/mediapipe/tasks/web/components/processors/label_map.ts
+++ b/mediapipe/tasks/web/components/processors/label_map.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2026 The MediaPipe Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+
+/** Category names and locale display names, aligned by class index. */
+export interface CategoryLabelMap {
+  labels: string[];
+  displayNames: string[];
+}
+
+/**
+ * Converts a TFLite / MediaPipe label_items map into parallel arrays.
+ *
+ * Index `i` is `categoryName` / `displayName` for class id `i`. Missing
+ * display names become an empty string so callers can zip the arrays.
+ */
+export function categoryLabelMapFromItems(
+  labelItems: {
+    forEach: (
+      callback: (value: LabelMapItem, key: string | number) => void,
+    ) => void;
+  },
+): CategoryLabelMap {
+  const labels: string[] = [];
+  const displayNames: string[] = [];
+  labelItems.forEach((value, index) => {
+    const i = Number(index);
+    labels[i] = value.getName() ?? '';
+    displayNames[i] = value.getDisplayName() ?? '';
+  });
+  return {labels, displayNames};
+}
+
+/**
+ * Finds expanded-graph nodes whose name or calculator type contains
+ * `calculatorName`. Throws if more than one node matches.
+ */
+export function findUniqueCalculatorNode(
+  graphConfig: CalculatorGraphConfig,
+  calculatorName: string,
+): CalculatorGraphConfig.Node | undefined {
+  const nodes = graphConfig.getNodeList().filter(
+    (n: CalculatorGraphConfig.Node) =>
+      n.getName().includes(calculatorName) ||
+      n.getCalculator().includes(calculatorName),
+  );
+  if (nodes.length > 1) {
+    throw new Error(`The graph has more than one ${calculatorName}.`);
+  }
+  return nodes[0];
+}

--- a/mediapipe/tasks/web/components/processors/label_map_test.ts
+++ b/mediapipe/tasks/web/components/processors/label_map_test.ts
@@ -33,11 +33,27 @@ describe('categoryLabelMapFromItems', () => {
     items.set(0, apple);
     const banana = new LabelMapItem();
     banana.setName('banana');
+    banana.setDisplayName('plátano');
     items.set(1, banana);
 
     expect(categoryLabelMapFromItems(items)).toEqual({
       labels: ['apple', 'banana'],
-      displayNames: ['manzana', ''],
+      displayNames: ['manzana', 'plátano'],
+    });
+  });
+
+  it('returns no display names when the labelmap has none', () => {
+    const items = new Map<number, LabelMapItem>();
+    const cat = new LabelMapItem();
+    cat.setName('cat');
+    items.set(0, cat);
+    const dog = new LabelMapItem();
+    dog.setName('dog');
+    items.set(1, dog);
+
+    expect(categoryLabelMapFromItems(items)).toEqual({
+      labels: ['cat', 'dog'],
+      displayNames: [],
     });
   });
 

--- a/mediapipe/tasks/web/components/processors/label_map_test.ts
+++ b/mediapipe/tasks/web/components/processors/label_map_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 The MediaPipe Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jasmine';
+
+import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+
+import {
+  categoryLabelMapFromItems,
+  findUniqueCalculatorNode,
+} from './label_map';
+
+describe('categoryLabelMapFromItems', () => {
+  it('aligns names and display names by class index', () => {
+    const items = new Map<number, LabelMapItem>();
+    const apple = new LabelMapItem();
+    apple.setName('apple');
+    apple.setDisplayName('manzana');
+    items.set(0, apple);
+    const banana = new LabelMapItem();
+    banana.setName('banana');
+    items.set(1, banana);
+
+    expect(categoryLabelMapFromItems(items)).toEqual({
+      labels: ['apple', 'banana'],
+      displayNames: ['manzana', ''],
+    });
+  });
+
+  it('returns empty arrays for an empty map', () => {
+    expect(categoryLabelMapFromItems(new Map())).toEqual({
+      labels: [],
+      displayNames: [],
+    });
+  });
+});
+
+describe('findUniqueCalculatorNode', () => {
+  it('returns undefined when the graph has no matching node', () => {
+    expect(
+      findUniqueCalculatorNode(
+        new CalculatorGraphConfig(),
+        'TensorsToClassificationCalculator',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('throws when more than one node matches', () => {
+    const graph = new CalculatorGraphConfig();
+    const a = new CalculatorGraphConfig.Node();
+    a.setCalculator('TensorsToClassificationCalculator');
+    const b = new CalculatorGraphConfig.Node();
+    b.setName('TensorsToClassificationCalculator');
+    graph.addNode(a);
+    graph.addNode(b);
+
+    expect(() =>
+      findUniqueCalculatorNode(graph, 'TensorsToClassificationCalculator'),
+    ).toThrowError(/more than one/);
+  });
+});

--- a/mediapipe/tasks/web/text/text_classifier/BUILD
+++ b/mediapipe/tasks/web/text/text_classifier/BUILD
@@ -17,6 +17,7 @@ ts_library(
     visibility = ["//visibility:public"],
     deps = [
         ":text_classifier_types",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
         "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/tasks/cc/components/containers/proto:classifications_jspb_proto",
@@ -26,6 +27,7 @@ ts_library(
         "//mediapipe/tasks/web/components/containers:classification_result",
         "//mediapipe/tasks/web/components/processors:classifier_options",
         "//mediapipe/tasks/web/components/processors:classifier_result",
+        "//mediapipe/tasks/web/components/processors:label_map",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:classifier_options",
         "//mediapipe/tasks/web/core:task_runner",
@@ -56,11 +58,15 @@ ts_library(
     ],
     deps = [
         ":text_classifier",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/framework/formats:classification_jspb_proto",
         "//mediapipe/tasks/cc/components/containers/proto:classifications_jspb_proto",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:task_runner_test_utils",
+        "//mediapipe/util:label_map_jspb_proto",
+        "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
 

--- a/mediapipe/tasks/web/text/text_classifier/text_classifier.ts
+++ b/mediapipe/tasks/web/text/text_classifier/text_classifier.ts
@@ -202,12 +202,14 @@ export class TextClassifier extends TaskRunner {
   }
 
   /**
-   * Get the locale display-name list for the current model. Index-aligned
-   * with {@link getLabels}. Entries are empty strings when the model has no
-   * display name for that class.
+   * Get the locale display-name list for the current model.
+   *
+   * When the model includes a display-name associated file, the returned list
+   * is the same length as {@link getLabels} and index-aligned with it. When
+   * the model has no display names, an empty array is returned.
    *
    * @export
-   * @return The display names used by the current model.
+   * @return The display names used by the current model, or `[]` if none.
    */
   getDisplayNames(): string[] {
     return this.displayNames;

--- a/mediapipe/tasks/web/text/text_classifier/text_classifier.ts
+++ b/mediapipe/tasks/web/text/text_classifier/text_classifier.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
 import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {ClassificationResult} from '../../../../tasks/cc/components/containers/proto/classifications_pb';
@@ -21,6 +22,10 @@ import {BaseOptions as BaseOptionsProto} from '../../../../tasks/cc/core/proto/b
 import {TextClassifierGraphOptions} from '../../../../tasks/cc/text/text_classifier/proto/text_classifier_graph_options_pb';
 import {convertClassifierOptionsToProto} from '../../../../tasks/web/components/processors/classifier_options';
 import {convertFromClassificationResultProto} from '../../../../tasks/web/components/processors/classifier_result';
+import {
+  categoryLabelMapFromItems,
+  findUniqueCalculatorNode,
+} from '../../../../tasks/web/components/processors/label_map';
 import {
   CachedGraphRunner,
   TaskRunner,
@@ -43,6 +48,8 @@ const INPUT_STREAM = 'text_in';
 const CLASSIFICATIONS_STREAM = 'classifications_out';
 const TEXT_CLASSIFIER_GRAPH =
   'mediapipe.tasks.text.text_classifier.TextClassifierGraph';
+const TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME =
+  'TensorsToClassificationCalculator';
 
 // The OSS JS API does not support the builder pattern.
 // tslint:disable:jspb-use-builder-pattern
@@ -50,6 +57,8 @@ const TEXT_CLASSIFIER_GRAPH =
 /** Performs Natural Language classification. */
 export class TextClassifier extends TaskRunner {
   private classificationResult: TextClassifierResult = {classifications: []};
+  private labels: string[] = [];
+  private displayNames: string[] = [];
   private readonly options = new TextClassifierGraphOptions();
 
   /**
@@ -146,6 +155,62 @@ export class TextClassifier extends TaskRunner {
       ),
     );
     return this.applyOptions(options);
+  }
+
+  protected override onGraphRefreshed(): void {
+    this.populateLabels();
+  }
+
+  /**
+   * Populate labels from TensorsToClassificationCalculator in the expanded
+   * graph. The calculator is configured from TFLite Model Metadata when the
+   * TextClassifier graph is built.
+   */
+  private populateLabels(): void {
+    this.labels = [];
+    this.displayNames = [];
+    const node = findUniqueCalculatorNode(
+      this.getCalculatorGraphConfig(),
+      TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME,
+    );
+    if (!node) {
+      return;
+    }
+    const labelItems =
+      node
+        .getOptions()
+        ?.getExtension(TensorsToClassificationCalculatorOptions.ext)
+        ?.getLabelItemsMap() ?? new Map();
+    const labelMap = categoryLabelMapFromItems(labelItems);
+    this.labels = labelMap.labels;
+    this.displayNames = labelMap.displayNames;
+  }
+
+  /**
+   * Get the category label list the TextClassifier can recognize. The index
+   * in the returned array corresponds to the category index in the model
+   * label map.
+   *
+   * If there is no labelmap provided in the model file, an empty array is
+   * returned.
+   *
+   * @export
+   * @return The labels used by the current model.
+   */
+  getLabels(): string[] {
+    return this.labels;
+  }
+
+  /**
+   * Get the locale display-name list for the current model. Index-aligned
+   * with {@link getLabels}. Entries are empty strings when the model has no
+   * display name for that class.
+   *
+   * @export
+   * @return The display names used by the current model.
+   */
+  getDisplayNames(): string[] {
+    return this.displayNames;
   }
 
   protected override get baseOptions(): BaseOptionsProto {

--- a/mediapipe/tasks/web/text/text_classifier/text_classifier_test.ts
+++ b/mediapipe/tasks/web/text/text_classifier/text_classifier_test.ts
@@ -17,10 +17,17 @@
 import 'jasmine';
 
 // Placeholder for internal dependency on encodeByteArray
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {Classification, ClassificationList} from '../../../../framework/formats/classification_pb';
 import {ClassificationResult, Classifications} from '../../../../tasks/cc/components/containers/proto/classifications_pb';
 import {addJasmineCustomFloatEqualityTester, createSpyWasmModule, MediapipeTasksFake, SpyWasmModule, verifyGraph, verifyListenersRegistered} from '../../../../tasks/web/core/task_runner_test_utils';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+import {
+  CALCULATOR_GRAPH_CONFIG_LISTENER_NAME,
+  SimpleListener,
+} from '../../../../web/graph_runner/graph_runner';
 
 import {TextClassifier} from './text_classifier';
 
@@ -154,6 +161,59 @@ describe('TextClassifier', () => {
         headIndex: 1,
         headName: 'headName'
       }]
+    });
+  });
+
+  describe('getLabels() and getDisplayNames()', () => {
+    function graphConfigWithLabels(
+        entries: Array<{name: string; displayName?: string}>): Uint8Array {
+      const graph = new CalculatorGraphConfig();
+      const node = new CalculatorGraphConfig.Node();
+      node.setName('TensorsToClassificationCalculator');
+      node.setCalculator('TensorsToClassificationCalculator');
+
+      const labelOptions = new TensorsToClassificationCalculatorOptions();
+      entries.forEach((entry, index) => {
+        const item = new LabelMapItem();
+        item.setName(entry.name);
+        if (entry.displayName !== undefined) {
+          item.setDisplayName(entry.displayName);
+        }
+        labelOptions.getLabelItemsMap().set(index, item);
+      });
+
+      const calculatorOptions = new CalculatorOptions();
+      calculatorOptions.setExtension(
+          TensorsToClassificationCalculatorOptions.ext, labelOptions);
+      node.setOptions(calculatorOptions);
+      graph.addNode(node);
+      return graph.serializeBinary();
+    }
+
+    async function loadLabelMap(
+        entries: Array<{name: string; displayName?: string}>): Promise<void> {
+      textClassifier.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (textClassifier.fakeWasmModule.simpleListeners![
+           CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+         ] as SimpleListener<Uint8Array>)(graphConfigWithLabels(entries), 0);
+      });
+      await textClassifier.setOptions(
+          {baseOptions: {modelAssetBuffer: new Uint8Array([1])}});
+    }
+
+    it('returns empty lists when the model has no labelmap', () => {
+      expect(textClassifier.getLabels()).toEqual([]);
+      expect(textClassifier.getDisplayNames()).toEqual([]);
+    });
+
+    it('returns labels and display names from the model metadata', async () => {
+      await loadLabelMap([
+        {name: 'positive', displayName: 'positivo'},
+        {name: 'negative', displayName: 'negativo'},
+      ]);
+
+      expect(textClassifier.getLabels()).toEqual(['positive', 'negative']);
+      expect(textClassifier.getDisplayNames()).toEqual(['positivo', 'negativo']);
     });
   });
 });

--- a/mediapipe/tasks/web/vision/image_classifier/BUILD
+++ b/mediapipe/tasks/web/vision/image_classifier/BUILD
@@ -16,6 +16,7 @@ ts_library(
     visibility = ["//visibility:public"],
     deps = [
         ":image_classifier_types",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
         "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/tasks/cc/components/containers/proto:classifications_jspb_proto",
@@ -25,6 +26,7 @@ ts_library(
         "//mediapipe/tasks/web/components/containers:classification_result",
         "//mediapipe/tasks/web/components/processors:classifier_options",
         "//mediapipe/tasks/web/components/processors:classifier_result",
+        "//mediapipe/tasks/web/components/processors:label_map",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:classifier_options",
         "//mediapipe/tasks/web/vision/core:image_processing_options",
@@ -57,11 +59,15 @@ ts_library(
     deps = [
         ":image_classifier",
         ":image_classifier_types",
+        "//mediapipe/calculators/tensor:tensors_to_classification_calculator_jspb_proto",
         "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/framework:calculator_options_jspb_proto",
         "//mediapipe/framework/formats:classification_jspb_proto",
         "//mediapipe/tasks/cc/components/containers/proto:classifications_jspb_proto",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:task_runner_test_utils",
+        "//mediapipe/util:label_map_jspb_proto",
+        "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
 

--- a/mediapipe/tasks/web/vision/image_classifier/image_classifier.ts
+++ b/mediapipe/tasks/web/vision/image_classifier/image_classifier.ts
@@ -214,12 +214,14 @@ export class ImageClassifier extends VisionTaskRunner {
   }
 
   /**
-   * Get the locale display-name list for the current model. Index-aligned
-   * with {@link getLabels}. Entries are empty strings when the model has no
-   * display name for that class.
+   * Get the locale display-name list for the current model.
+   *
+   * When the model includes a display-name associated file, the returned list
+   * is the same length as {@link getLabels} and index-aligned with it. When
+   * the model has no display names, an empty array is returned.
    *
    * @export
-   * @return The display names used by the current model.
+   * @return The display names used by the current model, or `[]` if none.
    */
   getDisplayNames(): string[] {
     return this.displayNames;

--- a/mediapipe/tasks/web/vision/image_classifier/image_classifier.ts
+++ b/mediapipe/tasks/web/vision/image_classifier/image_classifier.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
 import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {ClassificationResult} from '../../../../tasks/cc/components/containers/proto/classifications_pb';
@@ -21,6 +22,10 @@ import {BaseOptions as BaseOptionsProto} from '../../../../tasks/cc/core/proto/b
 import {ImageClassifierGraphOptions} from '../../../../tasks/cc/vision/image_classifier/proto/image_classifier_graph_options_pb';
 import {convertClassifierOptionsToProto} from '../../../../tasks/web/components/processors/classifier_options';
 import {convertFromClassificationResultProto} from '../../../../tasks/web/components/processors/classifier_result';
+import {
+  categoryLabelMapFromItems,
+  findUniqueCalculatorNode,
+} from '../../../../tasks/web/components/processors/label_map';
 import {WasmFileset} from '../../../../tasks/web/core/wasm_fileset';
 import {ImageProcessingOptions} from '../../../../tasks/web/vision/core/image_processing_options';
 import {
@@ -41,6 +46,8 @@ const IMAGE_CLASSIFIER_GRAPH =
 const IMAGE_STREAM = 'input_image';
 const NORM_RECT_STREAM = 'norm_rect';
 const CLASSIFICATIONS_STREAM = 'classifications';
+const TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME =
+  'TensorsToClassificationCalculator';
 
 export type {ImageClassifierOptions} from './image_classifier_options';
 export type {
@@ -56,6 +63,8 @@ export {type ImageSource}; // Used in the public API
 /** Performs classification on images. */
 export class ImageClassifier extends VisionTaskRunner {
   private classificationResult: ImageClassifierResult = {classifications: []};
+  private labels: string[] = [];
+  private displayNames: string[] = [];
   private readonly options = new ImageClassifierGraphOptions();
 
   /**
@@ -158,6 +167,62 @@ export class ImageClassifier extends VisionTaskRunner {
       ),
     );
     return this.applyOptions(options);
+  }
+
+  protected override onGraphRefreshed(): void {
+    this.populateLabels();
+  }
+
+  /**
+   * Populate labels from TensorsToClassificationCalculator in the expanded
+   * graph. The calculator is configured from TFLite Model Metadata when the
+   * ImageClassifier graph is built.
+   */
+  private populateLabels(): void {
+    this.labels = [];
+    this.displayNames = [];
+    const node = findUniqueCalculatorNode(
+      this.getCalculatorGraphConfig(),
+      TENSORS_TO_CLASSIFICATION_CALCULATOR_NAME,
+    );
+    if (!node) {
+      return;
+    }
+    const labelItems =
+      node
+        .getOptions()
+        ?.getExtension(TensorsToClassificationCalculatorOptions.ext)
+        ?.getLabelItemsMap() ?? new Map();
+    const labelMap = categoryLabelMapFromItems(labelItems);
+    this.labels = labelMap.labels;
+    this.displayNames = labelMap.displayNames;
+  }
+
+  /**
+   * Get the category label list the ImageClassifier can recognize. The index
+   * in the returned array corresponds to the category index in the model
+   * label map.
+   *
+   * If there is no labelmap provided in the model file, an empty array is
+   * returned.
+   *
+   * @export
+   * @return The labels used by the current model.
+   */
+  getLabels(): string[] {
+    return this.labels;
+  }
+
+  /**
+   * Get the locale display-name list for the current model. Index-aligned
+   * with {@link getLabels}. Entries are empty strings when the model has no
+   * display name for that class.
+   *
+   * @export
+   * @return The display names used by the current model.
+   */
+  getDisplayNames(): string[] {
+    return this.displayNames;
   }
 
   /**

--- a/mediapipe/tasks/web/vision/image_classifier/image_classifier_test.ts
+++ b/mediapipe/tasks/web/vision/image_classifier/image_classifier_test.ts
@@ -214,11 +214,11 @@ describe('ImageClassifier', () => {
       expect(imageClassifier.getDisplayNames()).toEqual(['manzana', 'plátano']);
     });
 
-    it('returns empty display names when the labelmap has none', async () => {
+    it('returns an empty list when the labelmap has no display names', async () => {
       await loadLabelMap([{name: 'cat'}, {name: 'dog'}]);
 
       expect(imageClassifier.getLabels()).toEqual(['cat', 'dog']);
-      expect(imageClassifier.getDisplayNames()).toEqual(['', '']);
+      expect(imageClassifier.getDisplayNames()).toEqual([]);
     });
   });
 });

--- a/mediapipe/tasks/web/vision/image_classifier/image_classifier_test.ts
+++ b/mediapipe/tasks/web/vision/image_classifier/image_classifier_test.ts
@@ -17,10 +17,17 @@
 import 'jasmine';
 
 // Placeholder for internal dependency on encodeByteArray
+import {TensorsToClassificationCalculatorOptions} from '../../../../calculators/tensor/tensors_to_classification_calculator_pb';
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
 import {Classification, ClassificationList} from '../../../../framework/formats/classification_pb';
 import {ClassificationResult, Classifications} from '../../../../tasks/cc/components/containers/proto/classifications_pb';
 import {addJasmineCustomFloatEqualityTester, createSpyWasmModule, MediapipeTasksFake, SpyWasmModule, verifyGraph, verifyListenersRegistered} from '../../../../tasks/web/core/task_runner_test_utils';
+import {LabelMapItem} from '../../../../util/label_map_pb';
+import {
+  CALCULATOR_GRAPH_CONFIG_LISTENER_NAME,
+  SimpleListener,
+} from '../../../../web/graph_runner/graph_runner';
 
 import {ImageClassifier} from './image_classifier';
 
@@ -152,6 +159,66 @@ describe('ImageClassifier', () => {
         headIndex: 1,
         headName: 'headName'
       }]
+    });
+  });
+
+  describe('getLabels() and getDisplayNames()', () => {
+    function graphConfigWithLabels(
+        entries: Array<{name: string; displayName?: string}>): Uint8Array {
+      const graph = new CalculatorGraphConfig();
+      const node = new CalculatorGraphConfig.Node();
+      node.setName('TensorsToClassificationCalculator');
+      node.setCalculator('TensorsToClassificationCalculator');
+
+      const labelOptions = new TensorsToClassificationCalculatorOptions();
+      entries.forEach((entry, index) => {
+        const item = new LabelMapItem();
+        item.setName(entry.name);
+        if (entry.displayName !== undefined) {
+          item.setDisplayName(entry.displayName);
+        }
+        labelOptions.getLabelItemsMap().set(index, item);
+      });
+
+      const calculatorOptions = new CalculatorOptions();
+      calculatorOptions.setExtension(
+          TensorsToClassificationCalculatorOptions.ext, labelOptions);
+      node.setOptions(calculatorOptions);
+      graph.addNode(node);
+      return graph.serializeBinary();
+    }
+
+    async function loadLabelMap(
+        entries: Array<{name: string; displayName?: string}>): Promise<void> {
+      imageClassifier.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (imageClassifier.fakeWasmModule.simpleListeners![
+           CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+         ] as SimpleListener<Uint8Array>)(graphConfigWithLabels(entries), 0);
+      });
+      await imageClassifier.setOptions(
+          {baseOptions: {modelAssetBuffer: new Uint8Array([1])}});
+    }
+
+    it('returns empty lists when the model has no labelmap', () => {
+      expect(imageClassifier.getLabels()).toEqual([]);
+      expect(imageClassifier.getDisplayNames()).toEqual([]);
+    });
+
+    it('returns labels and display names from the model metadata', async () => {
+      await loadLabelMap([
+        {name: 'apple', displayName: 'manzana'},
+        {name: 'banana', displayName: 'plátano'},
+      ]);
+
+      expect(imageClassifier.getLabels()).toEqual(['apple', 'banana']);
+      expect(imageClassifier.getDisplayNames()).toEqual(['manzana', 'plátano']);
+    });
+
+    it('returns empty display names when the labelmap has none', async () => {
+      await loadLabelMap([{name: 'cat'}, {name: 'dog'}]);
+
+      expect(imageClassifier.getLabels()).toEqual(['cat', 'dog']);
+      expect(imageClassifier.getDisplayNames()).toEqual(['', '']);
     });
   });
 });

--- a/mediapipe/tasks/web/vision/image_segmenter/BUILD
+++ b/mediapipe/tasks/web/vision/image_segmenter/BUILD
@@ -24,6 +24,7 @@ ts_library(
         "//mediapipe/tasks/cc/vision/image_segmenter/proto:segmenter_options_jspb_proto",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:classifier_options",
+        "//mediapipe/tasks/web/components/processors:label_map",
         "//mediapipe/tasks/web/vision/core:image_processing_options",
         "//mediapipe/tasks/web/vision/core:mask",
         "//mediapipe/tasks/web/vision/core:vision_task_runner",
@@ -48,10 +49,14 @@ ts_library(
         ":image_segmenter",
         ":image_segmenter_types",
         "//mediapipe/framework:calculator_jspb_proto",
+        "//mediapipe/framework:calculator_options_jspb_proto",
+        "//mediapipe/tasks/cc/vision/image_segmenter/calculators:tensors_to_segmentation_calculator_jspb_proto",
         "//mediapipe/tasks/web/core",
         "//mediapipe/tasks/web/core:task_runner_test_utils",
         "//mediapipe/tasks/web/vision/core:mask",
+        "//mediapipe/util:label_map_jspb_proto",
         "//mediapipe/web/graph_runner:graph_runner_image_lib_ts",
+        "//mediapipe/web/graph_runner:graph_runner_ts",
     ],
 )
 

--- a/mediapipe/tasks/web/vision/image_segmenter/image_segmenter.ts
+++ b/mediapipe/tasks/web/vision/image_segmenter/image_segmenter.ts
@@ -28,6 +28,7 @@ import {
   VisionTaskRunner,
 } from '../../../../tasks/web/vision/core/vision_task_runner';
 import {LabelMapItem} from '../../../../util/label_map_pb';
+import {categoryLabelMapFromItems} from '../../../../tasks/web/components/processors/label_map';
 import {
   ImageSource,
   WasmModule,
@@ -70,6 +71,7 @@ export class ImageSegmenter extends VisionTaskRunner {
   private confidenceMasks?: MPMask[];
   private qualityScores?: number[];
   private labels: string[] = [];
+  private displayNames: string[] = [];
   private userCallback?: ImageSegmenterCallback;
   private outputCategoryMask = DEFAULT_OUTPUT_CATEGORY_MASK;
   private outputConfidenceMasks = DEFAULT_OUTPUT_CONFIDENCE_MASKS;
@@ -213,6 +215,7 @@ export class ImageSegmenter extends VisionTaskRunner {
       );
 
     this.labels = [];
+    this.displayNames = [];
     if (tensorsToSegmentationCalculators.length > 1) {
       throw new Error(
         `The graph has more than one ${TENSORS_TO_SEGMENTATION_CALCULATOR_NAME}.`,
@@ -223,10 +226,9 @@ export class ImageSegmenter extends VisionTaskRunner {
           .getOptions()
           ?.getExtension(TensorsToSegmentationCalculatorOptions.ext)
           ?.getLabelItemsMap() ?? new Map<string, LabelMapItem>();
-      labelItems.forEach((value, index) => {
-        // tslint:disable-next-line:no-unnecessary-type-assertion
-        this.labels[Number(index)] = value.getName()!;
-      });
+      const labelMap = categoryLabelMapFromItems(labelItems);
+      this.labels = labelMap.labels;
+      this.displayNames = labelMap.displayNames;
     }
   }
 
@@ -416,6 +418,18 @@ export class ImageSegmenter extends VisionTaskRunner {
    */
   getLabels(): string[] {
     return this.labels;
+  }
+
+  /**
+   * Get the locale display-name list for the current model. Index-aligned
+   * with {@link getLabels}. Entries are empty strings when the model has no
+   * display name for that class.
+   *
+   * @export
+   * @return The display names used by the current model.
+   */
+  getDisplayNames(): string[] {
+    return this.displayNames;
   }
 
   private reset(): void {

--- a/mediapipe/tasks/web/vision/image_segmenter/image_segmenter.ts
+++ b/mediapipe/tasks/web/vision/image_segmenter/image_segmenter.ts
@@ -421,12 +421,14 @@ export class ImageSegmenter extends VisionTaskRunner {
   }
 
   /**
-   * Get the locale display-name list for the current model. Index-aligned
-   * with {@link getLabels}. Entries are empty strings when the model has no
-   * display name for that class.
+   * Get the locale display-name list for the current model.
+   *
+   * When the model includes a display-name associated file, the returned list
+   * is the same length as {@link getLabels} and index-aligned with it. When
+   * the model has no display names, an empty array is returned.
    *
    * @export
-   * @return The display names used by the current model.
+   * @return The display names used by the current model, or `[]` if none.
    */
   getDisplayNames(): string[] {
     return this.displayNames;

--- a/mediapipe/tasks/web/vision/image_segmenter/image_segmenter_test.ts
+++ b/mediapipe/tasks/web/vision/image_segmenter/image_segmenter_test.ts
@@ -18,6 +18,8 @@ import 'jasmine';
 
 // Placeholder for internal dependency on encodeByteArray
 import {CalculatorGraphConfig} from '../../../../framework/calculator_pb';
+import {CalculatorOptions} from '../../../../framework/calculator_options_pb';
+import {TensorsToSegmentationCalculatorOptions} from '../../../../tasks/cc/vision/image_segmenter/calculators/tensors_to_segmentation_calculator_pb';
 import {
   addJasmineCustomFloatEqualityTester,
   createSpyWasmModule,
@@ -26,7 +28,12 @@ import {
   verifyGraph,
 } from '../../../../tasks/web/core/task_runner_test_utils';
 import {MPMask} from '../../../../tasks/web/vision/core/mask';
+import {LabelMapItem} from '../../../../util/label_map_pb';
 import {WasmImage} from '../../../../web/graph_runner/graph_runner_image_lib';
+import {
+  CALCULATOR_GRAPH_CONFIG_LISTENER_NAME,
+  SimpleListener,
+} from '../../../../web/graph_runner/graph_runner';
 
 import {ImageSegmenter} from './image_segmenter';
 import type {ImageSegmenterOptions} from './image_segmenter_options';
@@ -362,5 +369,57 @@ describe('ImageSegmenter', () => {
     const result = imageSegmenter.segment({} as HTMLImageElement);
     expect(result.confidenceMasks![0]).toBeInstanceOf(MPMask);
     result.close();
+  });
+
+  describe('getLabels() and getDisplayNames()', () => {
+    function graphConfigWithLabels(
+        entries: Array<{name: string; displayName?: string}>): Uint8Array {
+      const graph = new CalculatorGraphConfig();
+      const node = new CalculatorGraphConfig.Node();
+      node.setName('mediapipe.tasks.TensorsToSegmentationCalculator');
+
+      const labelOptions = new TensorsToSegmentationCalculatorOptions();
+      entries.forEach((entry, index) => {
+        const item = new LabelMapItem();
+        item.setName(entry.name);
+        if (entry.displayName !== undefined) {
+          item.setDisplayName(entry.displayName);
+        }
+        labelOptions.getLabelItemsMap().set(index, item);
+      });
+
+      const calculatorOptions = new CalculatorOptions();
+      calculatorOptions.setExtension(
+          TensorsToSegmentationCalculatorOptions.ext, labelOptions);
+      node.setOptions(calculatorOptions);
+      graph.addNode(node);
+      return graph.serializeBinary();
+    }
+
+    async function loadLabelMap(
+        entries: Array<{name: string; displayName?: string}>): Promise<void> {
+      imageSegmenter.fakeWasmModule._getGraphConfig.and.callFake(() => {
+        (imageSegmenter.fakeWasmModule.simpleListeners![
+           CALCULATOR_GRAPH_CONFIG_LISTENER_NAME
+         ] as SimpleListener<Uint8Array>)(graphConfigWithLabels(entries), 0);
+      });
+      await imageSegmenter.setOptions(
+          {baseOptions: {modelAssetBuffer: new Uint8Array([1])}});
+    }
+
+    it('returns empty lists when the model has no labelmap', () => {
+      expect(imageSegmenter.getLabels()).toEqual([]);
+      expect(imageSegmenter.getDisplayNames()).toEqual([]);
+    });
+
+    it('returns labels and display names from the model metadata', async () => {
+      await loadLabelMap([
+        {name: 'background', displayName: 'fondo'},
+        {name: 'person', displayName: 'persona'},
+      ]);
+
+      expect(imageSegmenter.getLabels()).toEqual(['background', 'person']);
+      expect(imageSegmenter.getDisplayNames()).toEqual(['fondo', 'persona']);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #6339 / #6294. `@marcusx2` asked for locale `displayNames` (not just `categoryName`) and for the same runtime label API on every task that returns `Category`, not only ObjectDetector.

- `ImageClassifier`, `TextClassifier`, and `AudioClassifier` now expose `getLabels(): string[]` and `getDisplayNames(): string[]`
- `ImageSegmenter` already had `getLabels()`; it now also has `getDisplayNames()`
- If the model has a display-name associated file, `getDisplayNames()` is the same length as `getLabels()` and index-aligned. If it has none, `getDisplayNames()` returns `[]` (same “absent” signal as `getLabels()`). No inference required.
- Shared helper reads the TFLite labelmap already written onto `TensorsToClassificationCalculator` / `TensorsToSegmentationCalculator` (same pattern as #6339 / `ImageSegmenter.getLabels()`)

ObjectDetector `getDisplayNames()` is intentionally not in this PR so it does not conflict with #6339. Once that lands it is a small add on the same calculator (`LabelMapItem.display_name`).

```ts
const classifier = await ImageClassifier.createFromOptions(vision, {
  baseOptions: { modelAssetPath: userModelUrl },
  displayNamesLocale: 'es',
});
classifier.getLabels();        // ["apple", "banana"]
classifier.getDisplayNames();  // ["manzana", "plátano"]  or  []
```

## Test plan

- Unit tests for empty labelmap, labels+display names, and labels without display names on ImageClassifier
- Same coverage on TextClassifier, AudioClassifier, ImageSegmenter
- Helper tests for index alignment and the unique-calculator guard
- Manual: load a custom classifier `.tflite` with Associated Files / display names and call both getters before `classify()`

Related to #6294

@marcusx2 @HarishPermal @schmidt-sebastian @kuaashish @tyrmullen @kalyan2789g